### PR TITLE
Add support for HEX and Float 

### DIFF
--- a/EtherCard.cpp
+++ b/EtherCard.cpp
@@ -281,6 +281,22 @@ void BufferFiller::emit_p(PGM_P fmt, ...) {
             case 'D':
                 wtoa(va_arg(ap, word), (char*) ptr);
                 break;
+            case 'T':
+                dtostrf	(	va_arg(ap, double), 10, 3, (char*)ptr );
+            break;
+            case 'H': {
+                char p1 =  va_arg(ap, word);
+                char p2;
+                p2 = (p1 >> 4) & 0x0F;
+                p1 = p1 & 0x0F;
+                if (p1 > 9) p1 += 0x07; // adjust 0x0a-0x0f to come out 'a'-'f'
+                p1 += 0x30;             // and complete
+                if (p2 > 9) p2 += 0x07; // adjust 0x0a-0x0f to come out 'a'-'f'
+                p2 += 0x30;             // and complete
+                *ptr++ = p2;
+                *ptr++ = p1;
+            continue;
+            }
             case 'S':
                 strcpy((char*) ptr, va_arg(ap, const char*));
                 break;


### PR DESCRIPTION
Add a float/double and a Hex format output to the BufferFiller::emit_p. Use $T for double/float and $H for 2char HEX. That way you shoud be able to output a lot more data then its decimal representation with hex, and a float value.
