### PR TITLE
Add an easier Arduino Mega support

### DIFF
--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -254,10 +254,17 @@ static int gNextPacketPtr;
 static byte selectBit;  // 0 = B0 = pin 8, 1 = B1 = pin 9, 2 = B2 = pin 10
 
 void ENC28J60::initSPI () {
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+    const byte SPI_SS   = 53;
+    const byte SPI_MOSI = 51;
+    const byte SPI_MISO = 50;
+    const byte SPI_SCK  = 52;
+#else
     const byte SPI_SS   = 10;
     const byte SPI_MOSI = 11;
     const byte SPI_MISO = 12;
     const byte SPI_SCK  = 13;
+#endif
     
     pinMode(SPI_SS, OUTPUT);
     pinMode(SPI_MOSI, OUTPUT);


### PR DESCRIPTION
SPI pins are different between The Arduino Mega, and the UNO, and so I added in this commit a preprocessor condition to switch between these two pin configurations.
