### PR TITLE
Added the possibility to fill long int to BufferFiller::emit_p()

### DIFF
--- a/EtherCard.cpp
+++ b/EtherCard.cpp
@@ -281,6 +281,9 @@ void BufferFiller::emit_p(PGM_P fmt, ...) {
             case 'D':
                 wtoa(va_arg(ap, word), (char*) ptr);
                 break;
+            case 'L':
+                ltoa(va_arg(ap, long), (char*) ptr, 10);
+                break;
             case 'S':
                 strcpy((char*) ptr, va_arg(ap, const char*));
                 break;


### PR DESCRIPTION
Previously, you couldn't fill directly long int to BufferFiller::emit_p() method, you had to convert your variable into a word, but the maximum value of a word is 65,535, and 2,147,483,647 in a long, to fill a long, you have to use $L instead of $D in the emit_p method
A long 2 times more memory, but sometimes (e.g : if you want to give the pressure in Pa) the 16 bits of the word are not enough.
