### PR TITLE
Minor change for EtherShield Consistency

### DIFF
--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -267,6 +267,7 @@ void ENC28J60::initSPI () {
 #endif
     
     pinMode(SPI_SS, OUTPUT);
+    digitalWrite(SPI_SS, HIGH);
     pinMode(SPI_MOSI, OUTPUT);
     pinMode(SPI_SCK, OUTPUT);   
     pinMode(SPI_MISO, INPUT);


### PR DESCRIPTION
The newest version of Nanode seem to hang during initialization. Adding this one line to the initialization function, as is done in the now-retired EtherShield library, fixes this problem. There have been other reports on the web of this problem surfacing - perhaps its intermittent. Please merge it in, thanks!
