### PR TITLE
Fragmented browseUrl response handling

### DIFF
--- a/EtherCard.cpp
+++ b/EtherCard.cpp
@@ -341,6 +341,7 @@ uint8_t EtherCard::dnsip[4];  // dns server
 uint8_t EtherCard::hisip[4];  // dns result
 uint16_t EtherCard::hisport = 80; // tcp port to browse to
 bool EtherCard::using_dhcp = false;
+bool EtherCard::persist_tcp_connection = false;
 
 uint8_t EtherCard::begin (const uint16_t size,
                            const uint8_t* macaddr,

--- a/EtherCard.h
+++ b/EtherCard.h
@@ -130,6 +130,8 @@ public:
   static uint8_t hisip[4];  // dns result
   static uint16_t hisport;  // tcp port to connect to (default 80)
   static bool using_dhcp;   // whether dhcp is active or not
+  static bool persist_tcp_connection; // whether to break connections on first packet received
+
   // EtherCard.cpp
   static uint8_t begin (const uint16_t size, const uint8_t* macaddr,
                         uint8_t csPin =8);  
@@ -164,6 +166,9 @@ public:
   // new stash-based API
   static uint8_t tcpSend ();
   static const char* tcpReply (byte fd);
+
+  static void persistTcpConnection(bool persist);
+
   // dhcp.cpp
   static void DhcpStateMachine(word len);
   static uint32_t dhcpStartTime ();

--- a/tcpip.cpp
+++ b/tcpip.cpp
@@ -631,8 +631,14 @@ word EtherCard::packetLoop (word plen) {
         if (tcpstart+len>plen)
           save_len = plen-tcpstart;
         (*client_tcp_result_cb)((gPB[TCP_DST_PORT_L_P]>>5)&0x7,0,tcpstart,save_len);
-		make_tcp_ack_from_any(len,TCP_FLAGS_PUSH_V|TCP_FLAGS_FIN_V);
-        tcp_client_state = 6;
+
+        if(persist_tcp_connection){
+            make_tcp_ack_from_any(len,TCP_FLAGS_PUSH_V);
+        }
+        else{
+		    make_tcp_ack_from_any(len,TCP_FLAGS_PUSH_V|TCP_FLAGS_FIN_V);
+            tcp_client_state = 6;
+        }
         return 0;
       }
     }
@@ -665,4 +671,8 @@ word EtherCard::packetLoop (word plen) {
     }
   }
   return 0;
+}
+
+void EtherCard::persistTcpConnection(bool persist){
+  persist_tcp_connection = persist;
 }


### PR DESCRIPTION
Addresses jcw/ethercard/issues/54. This pull request is an attempt to minimize impacting the existing functionality. The only way this pull request impacts existing functionality is if you expressly call ether.persistTcpConnection(true) from your program. If you do that, it seems to allow me to receive multiple fragmented TCP packets from the same connection. The callback function gets called once for each fragment, so at least you can scan the results for something you're looking for in the body.

On a sidenote, and not to sound overly critical here, but the packetLoop function scores pretty low on maintainability IMHO. I had to instrument he heck out of it and read through a whole lot of TCP/IP protocol content on the web to make sense of it (and wasn't really able to totally reconcile the logic). If someone could help document what it's _supposed_ to do in detail, I would be in favor of a rewrite at some point. I found this somewhat useful: http://www.gmckinney.info/resources/TCPIP_State_Transition_Diagram.pdf.
