### PR TITLE
F/multi port

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -143,6 +143,7 @@ public:
   static void initIp (uint8_t *myip,uint16_t wwwp);
   static void makeUdpReply (char *data,uint8_t len, uint16_t port);
   static uint16_t packetLoop (uint16_t plen);
+  static uint16_t accept(uint16_t port, uint16_t plen);
   static void httpServerReply (uint16_t dlen);
   static void setGwIp (const uint8_t *gwipaddr);
   static uint8_t clientWaitingGw ();

--- a/tcpip.cpp
+++ b/tcpip.cpp
@@ -557,6 +557,27 @@ byte EtherCard::packetLoopIcmpCheckReply (const byte *ip_monitoredhost) {
             check_ip_message_is_from(ip_monitoredhost);
 }
 
+word EtherCard::accept(const word port, word plen) {
+  word len;
+  len = get_tcp_data_len();
+  
+  if (gPB[TCP_DST_PORT_H_P] == (port >> 8) &&
+      gPB[TCP_DST_PORT_L_P] == ((byte) port)) {
+    if (gPB[TCP_FLAGS_P] & TCP_FLAGS_SYN_V)
+      make_tcp_synack_from_syn();
+    else if (gPB[TCP_FLAGS_P] & TCP_FLAGS_ACK_V) {
+      info_data_len = get_tcp_data_len();
+      if (info_data_len > 0) {
+        len = TCP_DATA_START; // TCP_DATA_START is a formula
+        if (len <= plen - 8)
+          return len;
+      } else if (gPB[TCP_FLAGS_P] & TCP_FLAGS_FIN_V)
+        make_tcp_ack_from_any(0,0);
+    }
+  }
+  return 0;
+}
+
 word EtherCard::packetLoop (word plen) {
   word len;
 
@@ -657,21 +678,7 @@ word EtherCard::packetLoop (word plen) {
     return 0;
   }
 
-  if (gPB[TCP_DST_PORT_H_P] == (hisport >> 8) &&
-      gPB[TCP_DST_PORT_L_P] == ((byte) hisport)) {
-    if (gPB[TCP_FLAGS_P] & TCP_FLAGS_SYN_V)
-      make_tcp_synack_from_syn();
-    else if (gPB[TCP_FLAGS_P] & TCP_FLAGS_ACK_V) {
-      info_data_len = get_tcp_data_len();
-      if (info_data_len > 0) {
-        len = TCP_DATA_START; // TCP_DATA_START is a formula
-        if (len <= plen - 8)
-          return len;
-      } else if (gPB[TCP_FLAGS_P] & TCP_FLAGS_FIN_V)
-        make_tcp_ack_from_any(0,0);
-    }
-  }
-  return 0;
+  return accept(hisport, plen);
 }
 
 void EtherCard::persistTcpConnection(bool persist){


### PR DESCRIPTION
I did a small refactor in the packetLoop method, to be able to listen to several ports on the same device. The idea was to move the 'accept' part into a separate method, so one could call it with a different port, if the packet is not for the original one. You can find an example in the commit message.

While it's definitely not suited for high traffic loads, I'm using it without troubles for more than a week now.

In the previous commit (b72da21) I did a quick & dirty fix to make it compile with gcc-avr 4.7.x. This is just pushing the trouble away, since the prog_char is deprecated now, and I just turned on the compatibility mode.

Please review my changes, and I'd be happy if you find it good enough to be merged into mainline.
