### PR TITLE
browseUrl

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -160,6 +160,9 @@ public:
   static uint8_t clientTcpReq (uint8_t (*r)(uint8_t,uint8_t,uint16_t,uint16_t),
                                uint16_t (*d)(uint8_t),uint16_t port);
   static void browseUrl (prog_char *urlbuf, const char *urlbuf_varpart,
+                         prog_char *hoststr, prog_char *header,
+                         void (*cb)(uint8_t,uint16_t,uint16_t));
+  static void browseUrl (prog_char *urlbuf, const char *urlbuf_varpart,
                          prog_char *hoststr,
                          void (*cb)(uint8_t,uint16_t,uint16_t));
   static void httpPost (prog_char *urlbuf, prog_char *hoststr,

--- a/tcpip.cpp
+++ b/tcpip.cpp
@@ -459,10 +459,10 @@ static word www_client_internal_datafill_cb(byte fd) {
     if (client_postval == 0) {
       bfill.emit_p(PSTR("GET $F$S HTTP/1.0\r\n"
                         "Host: $F\r\n"
-                        "Accept: text/html\r\n"
+                        "$F\r\n"
                         "\r\n"), client_urlbuf,
                                  client_urlbuf_var,
-                                 client_hoststr);
+                                 client_hoststr, client_additionalheaderline);
     } else {
       prog_char* ahl = client_additionalheaderline;
       bfill.emit_p(PSTR("POST $F HTTP/1.0\r\n"
@@ -493,10 +493,15 @@ static byte www_client_internal_result_cb(byte fd, byte statuscode, word datapos
   return 0;
 }
 
-void EtherCard::browseUrl (prog_char *urlbuf, const char *urlbuf_varpart, prog_char *hoststr,void (*callback)(byte,word,word)) {
+void EtherCard::browseUrl (prog_char *urlbuf, const char *urlbuf_varpart, prog_char *hoststr, void (*callback)(byte,word,word)) {
+  browseUrl(urlbuf, urlbuf_varpart, hoststr, PSTR("Accept: text/html"), callback);
+}
+
+void EtherCard::browseUrl (prog_char *urlbuf, const char *urlbuf_varpart, prog_char *hoststr, prog_char *additionalheaderline, void (*callback)(byte,word,word)) {
   client_urlbuf = urlbuf;
   client_urlbuf_var = urlbuf_varpart;
   client_hoststr = hoststr;
+  client_additionalheaderline = additionalheaderline;
   client_postval = 0;
   client_browser_cb = callback;
   www_fd = clientTcpReq(&www_client_internal_result_cb,&www_client_internal_datafill_cb,hisport);


### PR DESCRIPTION
This patch adds a version of browseUrl which allows specifying a header (e.g., to allow "accept" headers).
