### PR TITLE
static bool dhcpSetup (const char *) implemented on dhcp.cpp

### DIFF
--- a/dhcp.cpp
+++ b/dhcp.cpp
@@ -92,8 +92,10 @@ typedef struct {
 // timeouts im ms 
 #define DHCP_REQUEST_TIMEOUT 10000
 
+#define DHCP_HOSTNAME_MAX_LEN 32
+
 static byte dhcpState = DHCP_STATE_INIT;
-static char hostname[] = "Arduino-00";
+static char hostname[DHCP_HOSTNAME_MAX_LEN] = "Arduino-00";
 static uint32_t currentXid;
 static uint32_t stateTimer;
 static uint32_t leaseStart;
@@ -181,7 +183,7 @@ static void send_dhcp_message (void) {
     
     addToBuf(12);     // Host name Option
     addToBuf(10);
-    addBytes(10, (byte*) hostname);
+    addBytes(strlen(hostname), (byte*) hostname);
     
 	
 	if( dhcpState == DHCP_STATE_SELECTING) {
@@ -281,7 +283,23 @@ bool EtherCard::dhcpSetup () {
     return dhcpState == DHCP_STATE_BOUND ;
 }
 
+bool EtherCard::dhcpSetup (const char *hname) {
+	// Use during setup, as this discards all incoming requests until it returns.
+	// That shouldn't be a problem, because we don't have an IP-address yet.
+	// Will try 60 secs to obtain DHCP-lease.
 
+	 using_dhcp = true;
+
+	 strncpy(hostname, hname, DHCP_HOSTNAME_MAX_LEN);
+
+	 dhcpState = DHCP_STATE_INIT;
+	 word start = millis();	
+
+	 while (dhcpState != DHCP_STATE_BOUND && (word) (millis() - start) < 60000) {
+	  if (isLinkUp()) DhcpStateMachine(packetReceive());
+    }
+    return dhcpState == DHCP_STATE_BOUND ;
+}
 
 void EtherCard::DhcpStateMachine (word len) {
 


### PR DESCRIPTION
The static method dhcpSetup (const char *) is defined on EtherCard.h but is has not been implemented on dhcp.cpp

I need to configure the hostname of my Arduino application and I supposed that the already defined method was intended for this purpose.

Therefore:

1) I have created a constant called DHCP_HOSTNAME_MAX_LEN which holds the maximum size of the hostname. I chose a value of 32 for the constant, which seems enough for me.

2) I have used the constant in the definition of the hostname variable:
static char hostname[DHCP_HOSTNAME_MAX_LEN] = "Arduino-00";

3) I have modified the method send_dhcp_message() to adapt it to the variable-length hostname.

4) I have implemented the method dhcpSetup (const char *).
