### PR TITLE
Fix PROGMEM related compilation errors on newer versions of avr-gcc

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -165,14 +165,14 @@ public:
   static uint8_t clientWaitingGw ();
   static uint8_t clientTcpReq (uint8_t (*r)(uint8_t,uint8_t,uint16_t,uint16_t),
                                uint16_t (*d)(uint8_t),uint16_t port);
-  static void browseUrl (prog_char *urlbuf, const char *urlbuf_varpart,
-                         prog_char *hoststr, prog_char *header,
+  static void browseUrl (const prog_char *urlbuf, const char *urlbuf_varpart,
+                         const prog_char *hoststr, const prog_char *header,
                          void (*cb)(uint8_t,uint16_t,uint16_t));
-  static void browseUrl (prog_char *urlbuf, const char *urlbuf_varpart,
-                         prog_char *hoststr,
+  static void browseUrl (const prog_char *urlbuf, const char *urlbuf_varpart,
+                         const prog_char *hoststr,
                          void (*cb)(uint8_t,uint16_t,uint16_t));
-  static void httpPost (prog_char *urlbuf, prog_char *hoststr,
-                        prog_char *header, const char *postval,
+  static void httpPost (const prog_char *urlbuf, const prog_char *hoststr,
+                        const prog_char *header, const char *postval,
                         void (*cb)(uint8_t,uint16_t,uint16_t));
   static void ntpRequest (uint8_t *ntpip,uint8_t srcport);
   static uint8_t ntpProcessAnswer (uint32_t *time, uint8_t dstport_l);
@@ -205,7 +205,7 @@ public:
   static bool dhcpSetup (const char *);
   static bool dhcpSetup ();
   // dns.cpp
-  static bool dnsLookup (prog_char* name, bool fromRam =false);
+  static bool dnsLookup (const prog_char* name, bool fromRam =false);
   // webutil.cpp
   static void copyIp (uint8_t *dst, const uint8_t *src);
   static void copyMac (uint8_t *dst, const uint8_t *src);

--- a/dns.cpp
+++ b/dns.cpp
@@ -79,7 +79,7 @@ static void checkForDnsAnswer (uint16_t plen) {
 }
 
 // use during setup, as this discards all incoming requests until it returns
-bool EtherCard::dnsLookup (prog_char* name, bool fromRam) {
+bool EtherCard::dnsLookup (const prog_char* name, bool fromRam) {
   word start = millis();
   while (!isLinkUp() || clientWaitingGw()) {
     packetLoop(packetReceive());

--- a/examples/JeeUdp/JeeUdp.ino
+++ b/examples/JeeUdp/JeeUdp.ino
@@ -84,7 +84,7 @@ void setup (){
   ether.printIp("IP: ", ether.myip);
 }
 
-char okHeader[] PROGMEM = 
+const char okHeader[] PROGMEM = 
   "HTTP/1.0 200 OK\r\n"
   "Content-Type: text/html\r\n"
   "Pragma: no-cache\r\n"

--- a/examples/backSoon/backSoon.ino
+++ b/examples/backSoon/backSoon.ino
@@ -17,7 +17,7 @@ static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[500]; // tcp/ip send and receive buffer
 
-char page[] PROGMEM =
+const char page[] PROGMEM =
 "HTTP/1.0 503 Service Unavailable\r\n"
 "Content-Type: text/html\r\n"
 "Retry-After: 600\r\n"

--- a/examples/etherNode/etherNode.ino
+++ b/examples/etherNode/etherNode.ino
@@ -89,7 +89,7 @@ void setup(){
 #endif
 }
 
-char okHeader[] PROGMEM = 
+const char okHeader[] PROGMEM = 
     "HTTP/1.0 200 OK\r\n"
     "Content-Type: text/html\r\n"
     "Pragma: no-cache\r\n"

--- a/examples/getDHCPandDNS/getDHCPandDNS.ino
+++ b/examples/getDHCPandDNS/getDHCPandDNS.ino
@@ -8,7 +8,7 @@
 // ethernet interface mac address
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 // remote website name
-char website[] PROGMEM = "google.com";
+const char website[] PROGMEM = "google.com";
 
 byte Ethernet::buffer[700];
 static long timer;

--- a/examples/getStaticIP/getStaticIP.ino
+++ b/examples/getStaticIP/getStaticIP.ino
@@ -14,7 +14,7 @@ static byte gwip[] = { 192,168,1,1 };
 // remote website ip address and port
 static byte hisip[] = { 74,125,79,99 };
 // remote website name
-char website[] PROGMEM = "google.com";
+const char website[] PROGMEM = "google.com";
 
 byte Ethernet::buffer[300];   // a very small tcp/ip buffer is enough here
 static long timer;

--- a/examples/getViaDNS/getViaDNS.ino
+++ b/examples/getViaDNS/getViaDNS.ino
@@ -12,7 +12,7 @@ static byte myip[] = { 192,168,1,203 };
 // gateway ip address
 static byte gwip[] = { 192,168,1,1 };
 // remote website name
-char website[] PROGMEM = "google.com";
+const char website[] PROGMEM = "google.com";
 
 byte Ethernet::buffer[300];   // a very small tcp/ip buffer is enough here
 static long timer;

--- a/examples/noipClient/noipClient.ino
+++ b/examples/noipClient/noipClient.ino
@@ -30,12 +30,12 @@
 static byte mymac[] = {0xDD,0xDD,0xDD,0x00,0x00,0x01};
 
 // Insert your hostname and authentication string
-char noIP_host[] PROGMEM = "myhost.no-ip.info";
-char noIP_auth[] PROGMEM = "XXXXXXXXXX";
+const char noIP_host[] PROGMEM = "myhost.no-ip.info";
+const char noIP_auth[] PROGMEM = "XXXXXXXXXX";
 
 // Don't change these ones...
-char getIP_web[] PROGMEM = "www.lucadentella.it";
-char noIP_web[] PROGMEM = "dynupdate.no-ip.com";
+const char getIP_web[] PROGMEM = "www.lucadentella.it";
+const char noIP_web[] PROGMEM = "dynupdate.no-ip.com";
 
 // Some global variables
 byte Ethernet::buffer[700];

--- a/examples/pachube/pachube.ino
+++ b/examples/pachube/pachube.ino
@@ -10,7 +10,7 @@
 // ethernet interface mac address, must be unique on the LAN
 byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
-char website[] PROGMEM = "api.pachube.com";
+const char website[] PROGMEM = "api.pachube.com";
 
 byte Ethernet::buffer[700];
 uint32_t timer;

--- a/examples/twitter/twitter.ino
+++ b/examples/twitter/twitter.ino
@@ -26,7 +26,7 @@
 // ethernet interface mac address, must be unique on the LAN
 byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
-char website[] PROGMEM = "api.supertweet.net";
+const char website[] PROGMEM = "api.supertweet.net";
 
 
 byte Ethernet::buffer[700];

--- a/examples/webClient/webClient.ino
+++ b/examples/webClient/webClient.ino
@@ -9,7 +9,7 @@ static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 byte Ethernet::buffer[700];
 static uint32_t timer;
 
-char website[] PROGMEM = "www.google.com";
+const char website[] PROGMEM = "www.google.com";
 
 // called when the client request is complete
 static void my_callback (byte status, word off, word len) {

--- a/tcpip.cpp
+++ b/tcpip.cpp
@@ -24,7 +24,7 @@
 //#undef PROGMEM 
 //#define PROGMEM __attribute__(( section(".progmem.data") )) 
 //#undef PSTR 
-//#define PSTR(s) (__extension__({static prog_char c[] PROGMEM = (s); &c[0];}))
+//#define PSTR(s) (__extension__({static const prog_char c[] PROGMEM = (s); &c[0];}))
 
 static byte tcpclient_src_port_l=1; 
 static byte tcp_fd; // a file descriptor, will be encoded into the port
@@ -36,11 +36,11 @@ static word (*client_tcp_datafill_cb)(byte);
 #define TCPCLIENT_SRC_PORT_H 11
 static byte www_fd;
 static void (*client_browser_cb)(byte,word,word);
-static prog_char *client_additionalheaderline;
+static const prog_char *client_additionalheaderline;
 static const char *client_postval;
-static prog_char *client_urlbuf;
+static const prog_char *client_urlbuf;
 static const char *client_urlbuf_var;
-static prog_char *client_hoststr;
+static const prog_char *client_hoststr;
 static void (*icmp_cb)(byte *ip);
 static int16_t delaycnt=1;
 static byte gwmacaddr[6];
@@ -464,7 +464,7 @@ static word www_client_internal_datafill_cb(byte fd) {
                                  client_urlbuf_var,
                                  client_hoststr, client_additionalheaderline);
     } else {
-      prog_char* ahl = client_additionalheaderline;
+      const prog_char* ahl = client_additionalheaderline;
       bfill.emit_p(PSTR("POST $F HTTP/1.0\r\n"
                         "Host: $F\r\n"
                         "$F$S"
@@ -493,11 +493,11 @@ static byte www_client_internal_result_cb(byte fd, byte statuscode, word datapos
   return 0;
 }
 
-void EtherCard::browseUrl (prog_char *urlbuf, const char *urlbuf_varpart, prog_char *hoststr, void (*callback)(byte,word,word)) {
+void EtherCard::browseUrl (const prog_char *urlbuf, const char *urlbuf_varpart, const prog_char *hoststr, void (*callback)(byte,word,word)) {
   browseUrl(urlbuf, urlbuf_varpart, hoststr, PSTR("Accept: text/html"), callback);
 }
 
-void EtherCard::browseUrl (prog_char *urlbuf, const char *urlbuf_varpart, prog_char *hoststr, prog_char *additionalheaderline, void (*callback)(byte,word,word)) {
+void EtherCard::browseUrl (const prog_char *urlbuf, const char *urlbuf_varpart, const prog_char *hoststr, const prog_char *additionalheaderline, void (*callback)(byte,word,word)) {
   client_urlbuf = urlbuf;
   client_urlbuf_var = urlbuf_varpart;
   client_hoststr = hoststr;
@@ -507,7 +507,7 @@ void EtherCard::browseUrl (prog_char *urlbuf, const char *urlbuf_varpart, prog_c
   www_fd = clientTcpReq(&www_client_internal_result_cb,&www_client_internal_datafill_cb,hisport);
 }
 
-void EtherCard::httpPost (prog_char *urlbuf, prog_char *hoststr, prog_char *additionalheaderline,const char *postval,void (*callback)(byte,word,word)) {
+void EtherCard::httpPost (const prog_char *urlbuf, const prog_char *hoststr, const prog_char *additionalheaderline,const char *postval,void (*callback)(byte,word,word)) {
   client_urlbuf = urlbuf;
   client_hoststr = hoststr;
   client_additionalheaderline = additionalheaderline;


### PR DESCRIPTION
Apparently, the use of the `PROGMEM` attribute is only valid for `const` type declarations in some newer versions of the `avr-gcc` compiler.  Attempts to compile examples from the main-line `ethercard` library would result in errors like the following:

```
twitter.ino:29:16: error: variable ‘website’ must be const in order to be put into read-only section by means of ‘__attribute__((progmem))’
```

as confirmed using Arduino 1.0.3+dfsg-2 (Ubuntu 13.04) which uses the package gcc-avr 4.7.2-2.

This pull request implements a simple fix, adding the `const` keyword to all `PROGMEM` type declarations and function signatures containing `prog_char`.  The fixes are believed to address this existing issue (https://github.com/jcw/ethercard/issues/11) and to be backwards compatible for older versions of avr-gcc.

A [similar pull request](https://github.com/jcw/ethercard/pull/23) also allows compilation to proceed, but suggested replacing `prog_char` datatypes with `const char`.  However, these alternate changes might lead to "cryptic" bugs in handling pointers (ref. http://www.arduino.cc/en/Reference/PROGMEM), which is likely why that request was not merged - this should not be a problem with the changes herein.  Note that the Arduino reference suggests using the `prog_`\* datatypes even when declaring and initializing global variables using `PROGMEM` - these changes have not been made in this branch.
