### PR TITLE
Make the default CS pin match the comments

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -151,7 +151,7 @@ public:
 
   // EtherCard.cpp
   static uint8_t begin (const uint16_t size, const uint8_t* macaddr,
-                        uint8_t csPin =8);  
+                        uint8_t csPin =SS);  
   static bool staticSetup (const uint8_t* my_ip =0,
                             const uint8_t* gw_ip =0,
                              const uint8_t* dns_ip =0);


### PR DESCRIPTION
The comments at the top of EtherCard.h say to connect the CS pin to pin
10 on the Uno, but then the code defaults to using pin 8 instead...
