### PR TITLE
Changed pointer parameters in udpPrepare() and sendUdp() to be const

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -276,7 +276,7 @@ public:
   *     @param  dip Pointer to 4 byte destination IP address
   *     @param  dport Destination port
   */
-  static void udpPrepare (uint16_t sport, uint8_t *dip, uint16_t dport);
+  static void udpPrepare (uint16_t sport, const uint8_t *dip, uint16_t dport);
 
   /**   @brief  Transmit UDP packet
   *     @param  len Size of payload
@@ -290,8 +290,8 @@ public:
   *     @param  dip Pointer to 4 byte destination IP address
   *     @param  dport Destination port
   */
-  static void sendUdp (char *data,uint8_t len,uint16_t sport,
-                                              uint8_t *dip, uint16_t dport);
+  static void sendUdp (const char *data, uint8_t len, uint16_t sport,
+                       const uint8_t *dip, uint16_t dport);
   /**   @brief  Resister the function to handle ping events
   *     @param  cb Pointer to function
   */

--- a/tcpip.cpp
+++ b/tcpip.cpp
@@ -337,7 +337,7 @@ uint8_t EtherCard::ntpProcessAnswer (uint32_t *time,uint8_t dstport_l) {
   return 1;
 }
 
-void EtherCard::udpPrepare (uint16_t sport, uint8_t *dip, uint16_t dport) {
+void EtherCard::udpPrepare (uint16_t sport, const uint8_t *dip, uint16_t dport) {
   setMACandIPs(gwmacaddr, dip);
   // see http://tldp.org/HOWTO/Multicast-HOWTO-2.html
   // multicast or broadcast address, https://github.com/jcw/ethercard/issues/59
@@ -367,7 +367,8 @@ void EtherCard::udpTransmit (uint16_t datalen) {
   packetSend(UDP_HEADER_LEN+IP_HEADER_LEN+ETH_HEADER_LEN+datalen);
 }
 
-void EtherCard::sendUdp (char *data,uint8_t datalen,uint16_t sport, uint8_t *dip, uint16_t dport) {
+void EtherCard::sendUdp (const char *data, uint8_t datalen, uint16_t sport,
+                         const uint8_t *dip, uint16_t dport) {
   udpPrepare(sport, dip, dport);
   if (datalen>220)
     datalen = 220;


### PR DESCRIPTION
Hello,

I have changed the pointer parameter to const for the UDP functions - this makes it easier to pass in const char\* strings and more consistent with the other functions.

The functions are 'read-only', so shouldn't cause any issues.

nick.
