### PR TITLE
DHCP Hostname Support

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -442,7 +442,7 @@ public:
     *     @return <i>bool</i> True if DHCP successful
     *     @note   Blocks until DHCP complete or timeout after 60 seconds
     */
-    static bool dhcpSetup (const char *hname = NULL);
+    static bool dhcpSetup (const char *hname = NULL, bool fromRam =false);
 
     /**   @brief  Register a callback for a specific DHCP option number
     *     @param  <i>option</i> The option number to request from the DHCP server

--- a/dhcp.cpp
+++ b/dhcp.cpp
@@ -276,7 +276,7 @@ static bool dhcp_received_message_type (uint16_t len, byte msgType) {
     return false;
 }
 
-bool EtherCard::dhcpSetup (const char *hname) {
+bool EtherCard::dhcpSetup (const char *hname, bool fromRam) {
 	 // Use during setup, as this discards all incoming requests until it returns.
 	 // That shouldn't be a problem, because we don't have an IP-address yet.
 	 // Will try 60 secs to obtain DHCP-lease.
@@ -284,7 +284,12 @@ bool EtherCard::dhcpSetup (const char *hname) {
 	 using_dhcp = true;
     
    if(hname != NULL){   
-  	 strncpy(hostname, hname, DHCP_HOSTNAME_MAX_LEN);
+     if(fromRam){
+    	 strncpy(hostname, hname, DHCP_HOSTNAME_MAX_LEN);
+     }
+     else{
+       strncpy_P(hostname, hname, DHCP_HOSTNAME_MAX_LEN);
+     }
    }
    else{
      // Set a unique hostname, use Arduino-?? with last octet of mac address


### PR DESCRIPTION
This addresses and supercedes pull request https://github.com/jcw/ethercard/pull/88

I've used the testDHCP example with the following calling forms and confirmed they all work as expected using WireShark:

ether.dhcpSetup(); //existing behavior
ether.dhcpSetup(PSTR("Wicked")); // new (optional) behavior (default hostname in Flash)
ether.dhcpSetup("Device", true); // new (optional) behavior (hostname in RAM)
