### PR TITLE
updated examples to put Serial.print strings in flash instead of RAM and...

### DIFF
--- a/examples/JeeUdp/JeeUdp.ino
+++ b/examples/JeeUdp/JeeUdp.ino
@@ -84,7 +84,7 @@ void setup (){
   ether.printIp("IP: ", ether.myip);
 }
 
-char okHeader[] PROGMEM = 
+const char okHeader[] PROGMEM = 
   "HTTP/1.0 200 OK\r\n"
   "Content-Type: text/html\r\n"
   "Pragma: no-cache\r\n"

--- a/examples/etherNode/etherNode.ino
+++ b/examples/etherNode/etherNode.ino
@@ -89,7 +89,7 @@ void setup(){
 #endif
 }
 
-char okHeader[] PROGMEM = 
+const char okHeader[] PROGMEM = 
     "HTTP/1.0 200 OK\r\n"
     "Content-Type: text/html\r\n"
     "Pragma: no-cache\r\n"

--- a/examples/getDHCPandDNS/getDHCPandDNS.ino
+++ b/examples/getDHCPandDNS/getDHCPandDNS.ino
@@ -8,7 +8,7 @@
 // ethernet interface mac address
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 // remote website name
-const char website[] = "google.com";
+const char website[] PROGMEM = "google.com";
 
 byte Ethernet::buffer[700];
 static long timer;
@@ -50,6 +50,6 @@ void loop () {
   if (millis() > timer + REQUEST_RATE) {
     timer = millis();
     Serial.println("\n>>> REQ");
-    ether.browseUrl("/foo/", "bar", website, my_result_cb);
+    ether.browseUrl(PSTR("/foo/"), "bar", website, my_result_cb);
   }
 }

--- a/examples/noipClient/noipClient.ino
+++ b/examples/noipClient/noipClient.ino
@@ -51,19 +51,19 @@ Stash stash;
 void setup () {
 
   Serial.begin(57600);
-  Serial.println("NoIP Client Demo");
+  Serial.println(F("NoIP Client Demo"));
   Serial.println();
 
   if (!ether.begin(sizeof Ethernet::buffer, mymac, 10))
-    Serial.println( "Failed to access Ethernet controller");
+    Serial.println(F( "Failed to access Ethernet controller"));
   else
-    Serial.println("Ethernet controller initialized");
+    Serial.println(F("Ethernet controller initialized"));
   Serial.println();
 
   if (!ether.dhcpSetup())
-    Serial.println("Failed to get configuration from DHCP");
+    Serial.println(F("Failed to get configuration from DHCP"));
   else
-    Serial.println("DHCP configuration done");
+    Serial.println(F("DHCP configuration done"));
 
   ether.printIp("IP Address:\t", ether.myip);
   ether.printIp("Netmask:\t", ether.netmask);
@@ -76,7 +76,7 @@ void setup () {
   // Resolve IP for getIP_web and noIP_web 
   // and store them into global variables
   if (!ether.dnsLookup(getIP_web)) {
-    Serial.print("Unable to resolve IP for ");
+    Serial.print(F("Unable to resolve IP for "));
     SerialPrint_P(getIP_web);
     actual_status = STATUS_ERROR;
   } else {
@@ -85,7 +85,7 @@ void setup () {
     ether.printIp(" resolved to:\t", ether.hisip);
   }
   if (!ether.dnsLookup(noIP_web)) {
-    Serial.print("Unable to resolve IP for ");
+    Serial.print(F("Unable to resolve IP for "));
     SerialPrint_P(noIP_web);
     actual_status = STATUS_ERROR;
   } else {
@@ -116,7 +116,7 @@ void checkPublicIP() {
 
   if(millis() > check_ip_timer) {
 
-    Serial.print("Checking public IP... ");
+    Serial.print(F("Checking public IP... "));
 
 	// Create a request for GetIP service,
 	// set destination IP and send request saving session_id
@@ -147,7 +147,7 @@ void checkPublicIPResponse() {
 	// If we can't resolve actual IP for our hostname on NoIP,
 	// return to IDLE state and wait for the next interval
     if(!ether.dnsLookup(noIP_host)) {
-      Serial.print("Unable to resolve actual IP for ");
+      Serial.print(F("Unable to resolve actual IP for "));
       SerialPrint_P(noIP_host);
       Serial.println();
       actual_status = STATUS_IDLE;
@@ -162,19 +162,19 @@ void checkPublicIPResponse() {
         if(i < 3) dnsIp = dnsIp + ".";
       }
       SerialPrint_P(noIP_host);
-      Serial.print(" resolved to ");
+      Serial.print(F(" resolved to "));
       Serial.println(dnsIp);
       
 	  // If they are the same, we can sit down and wait for the next interval
       if(actualIp.compareTo(dnsIp) == 0) {
-        Serial.println("No update needed :)");
+        Serial.println(F("No update needed :)"));
         actual_status = STATUS_IDLE;
         attempt = 0;
         check_ip_timer = millis() + CHECK_IP_INTERVAL;        
       
 	  // Different? We'd better to update NoIP!
 	  } else {
-        Serial.println("Update needed :(");
+        Serial.println(F("Update needed :("));
         actual_status = STATUS_NOIP_NEEDS_UPDATE;
         attempt = 0;
       }
@@ -185,10 +185,10 @@ void checkPublicIPResponse() {
   // and wait for the next interval
   } else {
     if(millis() > request_timer) {
-      Serial.println(" no response :(");    
+      Serial.println(F(" no response :("));    
       actual_status = STATUS_IDLE;
       if(attempt == MAX_ATTEMPTS) {
-        Serial.println("Max number of attempts reached");
+        Serial.println(F("Max number of attempts reached"));
         attempt = 0;
         check_ip_timer = millis() + CHECK_IP_INTERVAL;
       }
@@ -198,7 +198,7 @@ void checkPublicIPResponse() {
 
 void updateNoIP() {
 
-  Serial.print("Updating NoIP...");
+  Serial.print(F("Updating NoIP..."));
 
   // Create a request for updating NoIP using NoIP API,
   // set destination IP and send request saving session_id
@@ -253,9 +253,9 @@ void checkNoIPResponse() {
   } else {
 
     if(millis() > request_timer) {
-      Serial.println("No response from NoIP");
+      Serial.println(F("No response from NoIP"));
       if(attempt == MAX_ATTEMPTS) {
-        Serial.println("Max number of attempts reached");
+        Serial.println(F("Max number of attempts reached"));
         actual_status = STATUS_IDLE;
         attempt = 0;
         check_ip_timer = millis() + CHECK_IP_INTERVAL;

--- a/examples/pachube/pachube.ino
+++ b/examples/pachube/pachube.ino
@@ -18,19 +18,19 @@ Stash stash;
 
 void setup () {
   Serial.begin(57600);
-  Serial.println("\n[webClient]");
+  Serial.println(F("\n[webClient]"));
 
   if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
-    Serial.println( "Failed to access Ethernet controller");
+    Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
-    Serial.println("DHCP failed");
+    Serial.println(F("DHCP failed"));
 
   ether.printIp("IP:  ", ether.myip);
   ether.printIp("GW:  ", ether.gwip);  
   ether.printIp("DNS: ", ether.dnsip);  
 
   if (!ether.dnsLookup(website))
-    Serial.println("DNS failed");
+    Serial.println(F("DNS failed"));
     
   ether.printIp("SRV: ", ether.hisip);
 }

--- a/examples/pings/pings.ino
+++ b/examples/pings/pings.ino
@@ -19,9 +19,9 @@ void setup () {
   Serial.println("\n[pings]");
   
   if (ether.begin(sizeof Ethernet::buffer, mymac) == 0)
-    Serial.println( "Failed to access Ethernet controller");
+    Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
-    Serial.println("DHCP failed");
+    Serial.println(F("DHCP failed"));
 
   ether.printIp("IP:  ", ether.myip);
   ether.printIp("GW:  ", ether.gwip);

--- a/examples/rbbb_server/rbbb_server.ino
+++ b/examples/rbbb_server/rbbb_server.ino
@@ -12,7 +12,7 @@ BufferFiller bfill;
 
 void setup () {
   if (ether.begin(sizeof Ethernet::buffer, mymac) == 0)
-    Serial.println( "Failed to access Ethernet controller");
+    Serial.println(F("Failed to access Ethernet controller"));
   ether.staticSetup(myip);
 }
 

--- a/examples/testDHCP/testDHCP.ino
+++ b/examples/testDHCP/testDHCP.ino
@@ -14,7 +14,7 @@ byte Ethernet::buffer[700];
 
 void setup () {
   Serial.begin(57600);
-  Serial.println("\n[testDHCP]");
+  Serial.println(F("\n[testDHCP]"));
 
   Serial.print("MAC: ");
   for (byte i = 0; i < 6; ++i) {
@@ -25,11 +25,11 @@ void setup () {
   Serial.println();
   
   if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
-    Serial.println( "Failed to access Ethernet controller");
+    Serial.println(F("Failed to access Ethernet controller"));
 
-  Serial.println("Setting up DHCP");
+  Serial.println(F("Setting up DHCP"));
   if (!ether.dhcpSetup())
-    Serial.println( "DHCP failed");
+    Serial.println(F("DHCP failed"));
   
   ether.printIp("My IP: ", ether.myip);
   ether.printIp("Netmask: ", ether.netmask);

--- a/examples/twitter/twitter.ino
+++ b/examples/twitter/twitter.ino
@@ -53,16 +53,16 @@ void setup () {
   Serial.println("\n[webClient]");
 
   if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
-    Serial.println( "Failed to access Ethernet controller");
+    Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
-    Serial.println("DHCP failed");
+    Serial.println(F("DHCP failed"));
 
   ether.printIp("IP:  ", ether.myip);
   ether.printIp("GW:  ", ether.gwip);  
   ether.printIp("DNS: ", ether.dnsip);  
 
   if (!ether.dnsLookup(website))
-    Serial.println("DNS failed");
+    Serial.println(F("DNS failed"));
     
   ether.printIp("SRV: ", ether.hisip);
 

--- a/examples/udpListener/udpListener.ino
+++ b/examples/udpListener/udpListener.ino
@@ -31,15 +31,15 @@ void udpSerialPrint(word port, byte ip[4], const char *data, word len) {
 
 void setup(){
   Serial.begin(57600);
-  Serial.println("\n[backSoon]");
+  Serial.println(F("\n[backSoon]"));
 
   if (ether.begin(sizeof Ethernet::buffer, mymac) == 0)
-    Serial.println( "Failed to access Ethernet controller");
+    Serial.println(F("Failed to access Ethernet controller"));
 #if STATIC
   ether.staticSetup(myip, gwip);
 #else
   if (!ether.dhcpSetup())
-    Serial.println("DHCP failed");
+    Serial.println(F("DHCP failed"));
 #endif
 
   ether.printIp("IP:  ", ether.myip);

--- a/examples/webClient/webClient.ino
+++ b/examples/webClient/webClient.ino
@@ -21,12 +21,12 @@ static void my_callback (byte status, word off, word len) {
 
 void setup () {
   Serial.begin(57600);
-  Serial.println("\n[webClient]");
+  Serial.println(F("\n[webClient]"));
 
   if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
-    Serial.println( "Failed to access Ethernet controller");
+    Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
-    Serial.println("DHCP failed");
+    Serial.println(F("DHCP failed"));
 
   ether.printIp("IP:  ", ether.myip);
   ether.printIp("GW:  ", ether.gwip);  


### PR DESCRIPTION
Make examples put strings in flash instead of RAM, fix browseUrl usage in getDHCPandDNS example, and declare PROGMEM strings as const in examples.

Addresses https://github.com/jcw/ethercard/issues/141 
Addresses https://github.com/jcw/ethercard/issues/135
