### PR TITLE
udp server callback

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -42,6 +42,7 @@
 typedef void (*UdpServerCallback)(
     uint16_t dest_port,    ///< Port the packet was sent to
     uint8_t src_ip[4],    ///< IP address of the sender
+    uint16_t src_port,    ///< Port the packet was sent from
     const char *data,   ///< UDP payload data
     uint16_t len);        ///< Length of the payload data
 

--- a/udpserver.cpp
+++ b/udpserver.cpp
@@ -61,6 +61,7 @@ bool EtherCard::udpServerHasProcessedPacket(uint16_t plen) {
             listeners[i].callback(
                 listeners[i].port,
                 gPB + IP_SRC_P,
+                (gPB[UDP_SRC_PORT_H_P] << 8) | gPB[UDP_SRC_PORT_L_P],
                 (const char *) (gPB + UDP_DATA_P),
                 datalen);
             packetProcessed = true;


### PR DESCRIPTION
This patch adds the sourceport to the callback.
That way the callback can send a reply.
I use this for an NTP server implementation for example.