### PR TITLE
fix ethercard issue with GW IP != DNS IP, but both are LAN IPs

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -313,6 +313,11 @@ public:
     */
     static uint8_t clientWaitingGw ();
 
+    /**   @brief  Check if got gateway DNS address (ARP lookup)
+    *     @return <i>unit8_t</i> True if DNS found
+    */
+    static uint8_t clientWaitingDns ();
+
     /**   @brief  Prepare a TCP request
     *     @param  result_cb Pointer to callback function that handles TCP result
     *     @param  datafill_cb Pointer to callback function that handles TCP data payload

--- a/dns.cpp
+++ b/dns.cpp
@@ -93,7 +93,7 @@ bool EtherCard::dnsLookup (const char* name, bool fromRam) {
         if ((word) (millis() - start) >= 30000)
             return false; //timeout waiting for link
     }
-    while(clientWaitingGw())
+    while(clientWaitingDns())
     {
         packetLoop(packetReceive());
         if ((word) (millis() - start) >= 30000)

--- a/tcpip.cpp
+++ b/tcpip.cpp
@@ -448,6 +448,12 @@ uint8_t EtherCard::clientWaitingGw () {
     return !(waitgwmac & WGW_HAVE_GW_MAC);
 }
 
+uint8_t EtherCard::clientWaitingDns () {
+    if(is_lan(myip, dnsip))
+        return !has_dns_mac;
+    return !(waitgwmac & WGW_HAVE_GW_MAC);
+}
+
 static uint8_t client_store_mac(uint8_t *source_ip, uint8_t *mac) {
     if (memcmp(gPB + ETH_ARP_SRC_IP_P, source_ip, 4) != 0)
         return 0;


### PR DESCRIPTION
This is a git-am of @swarren 's patch.

Fixes #166.

Pretty sure I've done this right.