### PR TITLE
Fix for DHCP hostname when MAC addresses has A-F in last two digits

### DIFF
--- a/dhcp.cpp
+++ b/dhcp.cpp
@@ -290,6 +290,12 @@ static bool dhcp_received_message_type (uint16_t len, byte msgType) {
     return false;
 }
 
+static char toAsciiHex(byte b) {
+    char c = b & 0x0f;
+    c += (c <= 9) ? '0' : 'A'-10;
+    return c;
+}
+
 bool EtherCard::dhcpSetup (const char *hname, bool fromRam) {
     // Use during setup, as this discards all incoming requests until it returns.
     // That shouldn't be a problem, because we don't have an IP-address yet.
@@ -307,8 +313,8 @@ bool EtherCard::dhcpSetup (const char *hname, bool fromRam) {
     }
     else {
         // Set a unique hostname, use Arduino-?? with last octet of mac address
-        hostname[8] = '0' + (mymac[5] >> 4);
-        hostname[9] = '0' + (mymac[5] & 0x0F);
+        hostname[8] = toAsciiHex(mymac[5] >> 4);
+        hostname[9] = toAsciiHex(mymac[5]);
     }
 
     dhcpState = DHCP_STATE_INIT;


### PR DESCRIPTION
It noticed that my DHCP server was seeing weird characters in the last two digits of the hostname.

Upon investigation I found that the code that copies the last two characters of the MAC address did not work when the MAC address contains the hex digits A-F.

I have tried to keep the code as concise as possible to keep the code size down (instead of using sprintf for example).
