### PR TITLE
Only start using IP address from DHCP server after DHCP_ACK

### DIFF
--- a/dhcp.cpp
+++ b/dhcp.cpp
@@ -149,7 +149,7 @@ static void addBytes (byte len, const byte* data) {
 // 61  Client-identifier
 // 255 End
 
-static void send_dhcp_message (void) {
+static void send_dhcp_message(uint8_t *requestip) {
 
     uint8_t allOnes[] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 
@@ -194,13 +194,12 @@ static void send_dhcp_message (void) {
     addToBuf(10);
     addBytes(10, (byte*) hostname);
 
-    if( dhcpState == DHCP_STATE_SELECTING) {
+    if (requestip != NULL) {
         addToBuf(50); // Request IP address
         addToBuf(4);
-        addBytes(4, EtherCard::myip);
+        addBytes(4, requestip);
 
-        // Request using server ip address
-        addToBuf(54); // Server IP address
+        addToBuf(54); // DHCP Server IP address
         addToBuf(4);
         addBytes(4, EtherCard::dhcpip);
     }
@@ -222,11 +221,33 @@ static void send_dhcp_message (void) {
     EtherCard::udpTransmit((bufPtr - gPB) - UDP_DATA_P);
 }
 
-static void process_dhcp_offer (uint16_t len) {
+static void process_dhcp_offer(uint16_t len, uint8_t *offeredip) {
     // Map struct onto payload
     DHCPdata *dhcpPtr = (DHCPdata*) (gPB + UDP_DATA_P);
+
     // Offered IP address is in yiaddr
+    EtherCard::copyIp(offeredip, dhcpPtr->yiaddr);
+
+    // Search for the 
+    byte *ptr = (byte*) (dhcpPtr + 1) + 4;
+    do {
+        byte option = *ptr++;
+        byte optionLen = *ptr++;
+        if (option == 54) {
+            EtherCard::copyIp(EtherCard::dhcpip, ptr);
+            break;
+        }
+        ptr += optionLen;
+    } while (ptr < gPB + len);
+}
+
+static void process_dhcp_ack(uint16_t len) {
+    // Map struct onto payload
+    DHCPdata *dhcpPtr = (DHCPdata*) (gPB + UDP_DATA_P);
+
+    // Allocated IP address is in yiaddr
     EtherCard::copyIp(EtherCard::myip, dhcpPtr->yiaddr);
+
     // Scan through variable length option list identifying options we want
     byte *ptr = (byte*) (dhcpPtr + 1) + 4;
     bool done = false;
@@ -251,9 +272,6 @@ static void process_dhcp_offer (uint16_t len) {
             if (leaseTime != DHCP_INFINITE_LEASE) {
                 leaseTime *= 1000;      // milliseconds
             }
-            break;
-        case 54:
-            EtherCard::copyIp(EtherCard::dhcpip, ptr);
             break;
         case 255:
             done = true;
@@ -328,7 +346,8 @@ void EtherCard::dhcpAddOptionCallback(uint8_t option, DhcpOptionCallback callbac
     dhcpCustomOptionCallback = callback;
 }
 
-void EtherCard::DhcpStateMachine (uint16_t len) {
+void EtherCard::DhcpStateMachine (uint16_t len)
+{
 
 #ifdef DHCPDEBUG
     if (dhcpState != DHCP_STATE_BOUND) {
@@ -356,7 +375,7 @@ void EtherCard::DhcpStateMachine (uint16_t len) {
     case DHCP_STATE_BOUND:
         //!@todo Due to millis() 49 day wrap-around, DHCP renewal may not work as expected
         if (leaseTime != DHCP_INFINITE_LEASE && millis() >= leaseStart + leaseTime) {
-            send_dhcp_message();
+            send_dhcp_message(myip);
             dhcpState = DHCP_STATE_RENEWING;
             stateTimer = millis();
         }
@@ -365,7 +384,7 @@ void EtherCard::DhcpStateMachine (uint16_t len) {
     case DHCP_STATE_INIT:
         currentXid = millis();
         memset(myip,0,4); // force ip 0.0.0.0
-        send_dhcp_message();
+        send_dhcp_message(NULL);
         enableBroadcast(true); //Temporarily enable broadcasts
         dhcpState = DHCP_STATE_SELECTING;
         stateTimer = millis();
@@ -373,8 +392,9 @@ void EtherCard::DhcpStateMachine (uint16_t len) {
 
     case DHCP_STATE_SELECTING:
         if (dhcp_received_message_type(len, DHCP_OFFER)) {
-            process_dhcp_offer(len);
-            send_dhcp_message();
+            uint8_t offeredip[4];
+            process_dhcp_offer(len, offeredip);
+            send_dhcp_message(offeredip);
             dhcpState = DHCP_STATE_REQUESTING;
             stateTimer = millis();
         } else {
@@ -388,6 +408,7 @@ void EtherCard::DhcpStateMachine (uint16_t len) {
     case DHCP_STATE_RENEWING:
         if (dhcp_received_message_type(len, DHCP_ACK)) {
             disableBroadcast(true); //Disable broadcast after temporary enable
+            process_dhcp_ack(len);
             leaseStart = millis();
             if (gwip[0] != 0) setGwIp(gwip); // why is this? because it initiates an arp request
             dhcpState = DHCP_STATE_BOUND;


### PR DESCRIPTION
I have been spending a lot of time staring at the EtherCard DHCP code and trying to work out why it doesn't work with my Juniper SRX100 router.

I used Wireshark to compare the DHCP packet exchanges that other client implementations performed and noticed a difference between them and the EtherCard implementation. In the EtherCard implementation it starts using the IP address sent by the server as soon as it receives the DHCP_OFFER packet. However other implementations don't start using the IP address until after client has requested that IP address and a DHCP_ACK packet is received back from the server.

From my reading of RFC2131, I cannot see any explicit about the source IP address to use when sending a DHCPREQUEST request packet, the closest statement I have found is:

"Once the DHCPACK message from the server arrives, the client is initialized and moves to BOUND state."

However I don't think it makes sense to start using the offered IP address until the DHCP has committed to its use (which happens after DHCPREQUEST) and the client has received an ACK.
