### PR TITLE
Added enablePromiscuous and disablePromiscuous to receive all messages in code

### DIFF
--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -17,6 +17,7 @@
 
 uint16_t ENC28J60::bufferSize;
 bool ENC28J60::broadcast_enabled = false;
+bool ENC28J60::promiscuous_enabled = false;
 
 // ENC28J60 Control Registers
 // Control register definitions are a combination of address,
@@ -524,6 +525,34 @@ void ENC28J60::enableMulticast () {
 
 void ENC28J60::disableMulticast () {
     writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_MCEN);
+}
+
+void ENC28J60::enablePromiscuous (bool temporary) {
+    writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_UCEN);
+    writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_ANDOR);
+    writeRegByte(ERXFCON, readRegByte(ERXFCON) | ERXFCON_CRCEN);
+    writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_PMEN);
+    writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_MPEN);
+    writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_HTEN);
+    writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_MCEN);
+    writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_BCEN);
+    if(!temporary)
+        promiscuous_enabled = true;
+}
+
+void ENC28J60::disablePromiscuous (bool temporary) {
+    if(!temporary)
+        promiscuous_enabled = false;
+    if(!promiscuous_enabled) {
+        writeRegByte(ERXFCON, readRegByte(ERXFCON) | ERXFCON_UCEN);
+        writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_ANDOR);
+        writeRegByte(ERXFCON, readRegByte(ERXFCON) | ERXFCON_CRCEN);
+        writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_PMEN);
+        writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_MPEN);
+        writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_HTEN);
+        writeRegByte(ERXFCON, readRegByte(ERXFCON) & ~ERXFCON_MCEN);
+        writeRegByte(ERXFCON, readRegByte(ERXFCON) | ERXFCON_BCEN);
+    }
 }
 
 uint8_t ENC28J60::doBIST ( byte csPin) {

--- a/enc28j60.h
+++ b/enc28j60.h
@@ -19,6 +19,7 @@ public:
     static uint8_t buffer[]; //!< Data buffer (shared by recieve and transmit)
     static uint16_t bufferSize; //!< Size of data buffer
     static bool broadcast_enabled; //!< True if broadcasts enabled (used to allow temporary disable of broadcast for DHCP or other internal functions)
+    static bool promiscuous_enabled; //!< True if promiscuous mode enabled (used to allow temporary disable of promiscuous mode)
 
     static uint8_t* tcpOffset () { return buffer + 0x36; } //!< Pointer to the start of TCP payload
 
@@ -96,6 +97,21 @@ public:
     *     @note   This will increase load on recieved data handling
     */
     static void enableMulticast ();
+    
+    /**   @brief  Enables reception of all messages
+    *     @param  temporary Set true to temporarily enable promiscuous
+    *     @note   This will increase load significantly on recieved data handling
+    *     @note   All messages will be accepted, even messages with destination MAC other than own
+    *     @note   Messages with invalid CRC checksum will still be rejected
+    */
+    static void enablePromiscuous (bool temporary = false);
+    
+    /**   @brief  Disable reception of all messages and go back to default mode
+    *     @param  temporary Set true to only disable if temporarily enabled
+    *     @note   This will reduce load on recieved data handling
+    *     @note   In this mode only unicast and broadcast messages will be received
+    */
+    static void disablePromiscuous(bool temporary = false);
 
     /**   @brief  Disable reception of mulitcast messages
     *     @note   This will reduce load on recieved data handling


### PR DESCRIPTION
This can be useful if you want to program e.g. a switch and you need to receive all messages. Not only messages with destination address of the own MAC address, multicast or broadcast.