### PR TITLE
change packetSend to check whether last package is done

### DIFF
--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -416,20 +416,116 @@ bool ENC28J60::isLinkUp() {
     return (readPhyByte(PHSTAT2) >> 2) & 1;
 }
 
+/*
+struct __attribute__((__packed__)) transmit_status_vector {
+    uint16_t transmitByteCount;
+    byte     transmitCollisionCount      :  4;
+    byte     transmitCrcError            :  1;
+    byte     transmitLengthCheckError    :  1;
+    byte     transmitLengthOutRangeError :  1;
+    byte     transmitDone                :  1;
+    byte     transmitMulticast           :  1;
+    byte     transmitBroadcast           :  1;
+    byte     transmitPacketDefer         :  1;
+    byte     transmitExcessiveDefer      :  1;
+    byte     transmitExcessiveCollision  :  1;
+    byte     transmitLateCollision       :  1;
+    byte     transmitGiant               :  1;
+    byte     transmitUnderrun            :  1;
+    uint16_t totalTransmitted; 
+    byte     transmitControlFrame        :  1;
+    byte     transmitPauseControlFrame   :  1;
+    byte     backpressureApplied         :  1;
+    byte     transmitVLAN                :  1;
+    byte     zero                        :  4;
+};
+*/
+
+struct transmit_status_vector {
+    uint8_t bytes[7];
+};
+
+#if ETHERCARD_SEND_PIPELINING
+    #define BREAKORCONTINUE retry=0; continue;
+#else
+    #define BREAKORCONTINUE break;
+#endif
+
 void ENC28J60::packetSend(uint16_t len) {
-    // see http://forum.mysensors.org/topic/536/
-    // while (readOp(ENC28J60_READ_CTRL_REG, ECON1) & ECON1_TXRTS)
-    if (readRegByte(EIR) & EIR_TXERIF) {
+    byte retry = 0;
+
+    #if ETHERCARD_SEND_PIPELINING
+        goto resume_last_transmission;
+    #endif
+    while (1) {
+        // latest errata sheet: DS80349C 
+        // always reset transmit logic (Errata Issue 12)
+        // the Microchip TCP/IP stack implementation used to first check
+        // whether TXERIF is set and only then reset the transmit logic
+        // but this has been changed in later versions; possibly they
+        // have a reason for this; they don't mention this in the errata 
+        // sheet
         writeOp(ENC28J60_BIT_FIELD_SET, ECON1, ECON1_TXRST);
-        writeOp(ENC28J60_BIT_FIELD_CLR, ECON1, ECON1_TXRST);
-        writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXERIF);
+        writeOp(ENC28J60_BIT_FIELD_CLR, ECON1, ECON1_TXRST); 
+        writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXERIF|EIR_TXIF);
+   
+        // prepare new transmission 
+        if (retry == 0) {
+            writeReg(EWRPT, TXSTART_INIT);
+            writeReg(ETXND, TXSTART_INIT+len);
+            writeOp(ENC28J60_WRITE_BUF_MEM, 0, 0x00);
+            writeBuf(len, buffer);
+        }
+   
+        // initiate transmission
+        writeOp(ENC28J60_BIT_FIELD_SET, ECON1, ECON1_TXRTS);
+        #if ETHERCARD_SEND_PIPELINING
+            if (retry == 0) return;
+        #endif
+
+    resume_last_transmission:
+
+        // wait until transmission has finished; referrring to the data sheet and 
+        // to the errata (Errata Issue 13; Example 1) you only need to wait until either 
+        // TXIF or TXERIF gets set; however this leads to hangs; apparently Microchip
+        // realized this and in later implementations of their tcp/ip stack they introduced 
+        // a counter to avoid hangs; of course they didn't update the errata sheet 
+        uint16_t count = 0;
+        while ((readRegByte(EIR) & (EIR_TXIF | EIR_TXERIF)) == 0 && ++count < 1000U)
+            ;
+   
+        if (!(readRegByte(EIR) & EIR_TXERIF) && count < 1000U) {
+            // no error; start new transmission
+            BREAKORCONTINUE
+        }
+   
+        // cancel previous transmission if stuck
+        writeOp(ENC28J60_BIT_FIELD_CLR, ECON1, ECON1_TXRTS); 
+    
+    #if ETHERCARD_RETRY_LATECOLLISIONS == 0
+        BREAKORCONTINUE
+    #endif
+
+        // Check whether the chip thinks that a late collision ocurred; the chip
+        // may be wrong (Errata Issue 13); therefore we retry. We could check
+        // LATECOL in the ESTAT register in order to find out whether the chip
+        // thinks a late collision ocurred but (Errata Issue 15) tells us that
+        // this is not working. Therefore we check TSV
+        transmit_status_vector tsv;   
+        uint16_t etxnd = readReg(ETXND);
+        writeReg(ERDPT, etxnd+1);
+        readBuf(sizeof(transmit_status_vector), (byte*) &tsv);
+        // LATECOL is bit number 29 in TSV (starting from 0)
+
+        if (!((readRegByte(EIR) & EIR_TXERIF) && (tsv.bytes[3] & 1<<5) /*tsv.transmitLateCollision*/) || retry > 16U) {
+            // there was some error but no LATECOL so we do not repeat
+            BREAKORCONTINUE
+        }
+        
+        retry++;
     }
-    writeReg(EWRPT, TXSTART_INIT);
-    writeReg(ETXND, TXSTART_INIT+len);
-    writeOp(ENC28J60_WRITE_BUF_MEM, 0, 0x00);
-    writeBuf(len, buffer);
-    writeOp(ENC28J60_BIT_FIELD_SET, ECON1, ECON1_TXRTS);
 }
+
 
 uint16_t ENC28J60::packetReceive() {
     static uint16_t gNextPacketPtr = RXSTART_INIT;

--- a/enc28j60.h
+++ b/enc28j60.h
@@ -9,6 +9,7 @@
 // chip, using an SPI interface to the host processor.
 //
 // 2010-05-20 <jc@wippler.nl>
+/** @file */
 
 #ifndef ENC28J60_H
 #define ENC28J60_H
@@ -127,4 +128,22 @@ public:
 
 typedef ENC28J60 Ethernet; //!< Define alias Ethernet for ENC28J60
 
+
+/** Workaround for Errata 13.
+*   The transmission hardware may drop some packets because it thinks a late collision
+*   occurred (which should never happen if all cable length etc. are ok). If setting
+*   this to 1 these packages will be retried a fixed number of times. Costs about 150bytes
+*   of flash.
+*/
+#define ETHERCARD_RETRY_LATECOLLISIONS 0
+
+/** Enable pipelining of packet transmissions.
+*   If enabled the packetSend function will not block/wait until the packet is actually
+*   transmitted; but instead this wait is shifted to the next time that packetSend is
+*   called. This gives higher performance; however in combination with 
+*   ETHERCARD_RETRY_LATECOLLISIONS this may lead to problems because a packet whose
+*   transmission fails because the ENC-chip thinks that it is a late collision will
+*   not be retried until the next call to packetSend.
+*/
+#define ETHERCARD_SEND_PIPELINING 0
 #endif


### PR DESCRIPTION
The last commit (1425b25d593d3fdca32f0f304c6841dd990ba7f8) that changed packetSend() had the side effect that now packetSend does not wait for the previous packet to finish but simply starts transmitting. This causes the previous packet or the current packet to be dropped. I am pretty certain that this e.g. causes issue #183.

I first tried to reimplement packetSend by following the latest errata. However, there it says you simply have to wait until either TXIF or TXERIF becomes set. This leads to hangs (http://forum.mysensors.org/topic/536/). Microchip has an implementation of a TCP/IP stack. In this implementation they do not follow their own errata sheet but introduced a counter that avoids hangs. I basically followed this implementation. I also implemented the workaround for Errata issue 13 regarding late collisions detected by the hardware by mistake.