### PR TITLE
efficiency improvements

### DIFF
--- a/EtherCard.cpp
+++ b/EtherCard.cpp
@@ -13,9 +13,12 @@
 #include <stdarg.h>
 #include <avr/eeprom.h>
 
+#define WRITEBUF  0
+#define READBUF   1
+
 //#define FLOATEMIT // uncomment line to enable $T in emit_P for float emitting
 
-byte Stash::map[256/8];
+byte Stash::map[SCRATCH_MAP_SIZE];
 Stash::Block Stash::bufs[2];
 
 uint8_t Stash::allocBlock () {
@@ -34,25 +37,29 @@ void Stash::freeBlock (uint8_t block) {
 }
 
 uint8_t Stash::fetchByte (uint8_t blk, uint8_t off) {
-    return blk == bufs[0].bnum ? bufs[0].bytes[off] :
-           blk == bufs[1].bnum ? bufs[1].bytes[off] :
+    return blk == bufs[WRITEBUF].bnum ? bufs[WRITEBUF].bytes[off] :
+           blk == bufs[READBUF].bnum ? bufs[READBUF].bytes[off] :
            ether.peekin(blk, off);
 }
 
-void Stash::initMap (uint8_t last) {
+
+// block 0 is special since always occupied
+void Stash::initMap (uint8_t last /*=SCRATCH_PAGE_NUM*/) {
+    last = SCRATCH_PAGE_NUM;
     while (--last > 0)
         freeBlock(last);
 }
 
+// load a page/block either into the write or into the readbuffer
 void Stash::load (uint8_t idx, uint8_t blk) {
     if (blk != bufs[idx].bnum) {
-        if (idx == 0) {
+        if (idx == WRITEBUF) {
             ether.copyout(bufs[idx].bnum, bufs[idx].bytes);
-            if (blk == bufs[1].bnum)
-                bufs[1].bnum = 255; // forget read page if same
-        } else if (blk == bufs[0].bnum) {
+            if (blk == bufs[READBUF].bnum)
+                bufs[READBUF].bnum = 255; // forget read page if same
+        } else if (blk == bufs[WRITEBUF].bnum) {
             // special case: read page is same as write buffer
-            memcpy(&bufs[1], &bufs[0], sizeof bufs[0]);
+            memcpy(&bufs[READBUF], &bufs[WRITEBUF], sizeof bufs[0]);
             return;
         }
         bufs[idx].bnum = blk;
@@ -62,38 +69,42 @@ void Stash::load (uint8_t idx, uint8_t blk) {
 
 uint8_t Stash::freeCount () {
     uint8_t count = 0;
-    for (uint8_t i = 0; i < 256/8; ++i)
+    for (uint8_t i = 0; i < sizeof map; ++i)
         for (uint8_t m = 0x80; m != 0; m >>= 1)
             if (map[i] & m)
                 ++count;
     return count;
 }
 
+// create a new stash; make it the active stash; return the first block as a handle 
 uint8_t Stash::create () {
     uint8_t blk = allocBlock();
-    load(0, blk);
-    bufs[0].head.count = 0;
-    bufs[0].head.first = bufs[0].head.last = blk;
-    bufs[0].tail = sizeof (StashHeader);
-    bufs[0].next = 0;
-    return open(blk);
+    load(WRITEBUF, blk);
+    bufs[WRITEBUF].head.count = 0;
+    bufs[WRITEBUF].head.first = bufs[0].head.last = blk;
+    bufs[WRITEBUF].tail = sizeof (StashHeader);
+    bufs[WRITEBUF].next = 0;
+    return open(blk); // you are now the active stash 
 }
 
+// the stashheader part only contains reasonable data if we are the first block
 uint8_t Stash::open (uint8_t blk) {
     curr = blk;
-    offs = sizeof (StashHeader);
-    load(1, curr);
-    memcpy((StashHeader*) this, bufs[1].bytes, sizeof (StashHeader));
+    offs = sizeof (StashHeader); // goto first byte
+    load(READBUF, curr);
+    memcpy((StashHeader*) this, bufs[READBUF].bytes, sizeof (StashHeader));
     return curr;
 }
 
+// save the metadata of current block into the first block
 void Stash::save () {
-    load(0, first);
-    memcpy(bufs[0].bytes, (StashHeader*) this, sizeof (StashHeader));
-    if (bufs[1].bnum == first)
-        load(1, 0); // invalidates original in case it was the same block
+    load(WRITEBUF, first);
+    memcpy(bufs[WRITEBUF].bytes, (StashHeader*) this, sizeof (StashHeader));
+    if (bufs[READBUF].bnum == first)
+        load(READBUF, 0); // invalidates original in case it was the same block
 }
 
+// follow the linked list of blocks and free every block
 void Stash::release () {
     while (first > 0) {
         freeBlock(first);
@@ -102,32 +113,33 @@ void Stash::release () {
 }
 
 void Stash::put (char c) {
-    load(0, last);
-    uint8_t t = bufs[0].tail;
-    bufs[0].bytes[t++] = c;
+    load(WRITEBUF, last);
+    uint8_t t = bufs[WRITEBUF].tail;
+    bufs[WRITEBUF].bytes[t++] = c;
     if (t <= 62)
-        bufs[0].tail = t;
+        bufs[WRITEBUF].tail = t;
     else {
-        bufs[0].next = allocBlock();
-        last = bufs[0].next;
-        load(0, last);
-        bufs[0].tail = bufs[0].next = 0;
+        bufs[WRITEBUF].next = allocBlock();
+        last = bufs[WRITEBUF].next;
+        load(WRITEBUF, last);
+        bufs[WRITEBUF].tail = bufs[WRITEBUF].next = 0;
         ++count;
     }
 }
 
 char Stash::get () {
-    load(1, curr);
-    if (curr == last && offs >= bufs[1].tail)
+    load(READBUF, curr);
+    if (curr == last && offs >= bufs[READBUF].tail)
         return 0;
-    uint8_t b = bufs[1].bytes[offs];
+    uint8_t b = bufs[READBUF].bytes[offs];
     if (++offs >= 63 && curr != last) {
-        curr = bufs[1].next;
+        curr = bufs[READBUF].next;
         offs = 0;
     }
     return b;
 }
 
+// fetchbyte(last, 62) is tail, i.e., number of characters in last block 
 uint16_t Stash::size () {
     return 63 * count + fetchByte(last, 62) - sizeof (StashHeader);
 }
@@ -140,9 +152,11 @@ static char* wtoa (uint16_t value, char* ptr) {
     return ptr;
 }
 
+// write information about the fmt string and the arguments into special page/block 0    
+// block 0 is initially marked as allocated and never returned by allocateBlock 
 void Stash::prepare (PGM_P fmt, ...) {
-    Stash::load(0, 0);
-    uint16_t* segs = Stash::bufs[0].words;
+    Stash::load(WRITEBUF, 0);
+    uint16_t* segs = Stash::bufs[WRITEBUF].words;
     *segs++ = strlen_P(fmt);
 #ifdef __AVR__
     *segs++ = (uint16_t) fmt;
@@ -194,20 +208,20 @@ void Stash::prepare (PGM_P fmt, ...) {
             *segs++ = argval;
             *segs++ = argval >> 16;
 #endif
-            Stash::bufs[0].words[0] += arglen - 2;
+            Stash::bufs[WRITEBUF].words[0] += arglen - 2;
         }
     }
     va_end(ap);
 }
 
 uint16_t Stash::length () {
-    Stash::load(0, 0);
-    return Stash::bufs[0].words[0];
+    Stash::load(WRITEBUF, 0);
+    return Stash::bufs[WRITEBUF].words[0];
 }
 
 void Stash::extract (uint16_t offset, uint16_t count, void* buf) {
-    Stash::load(0, 0);
-    uint16_t* segs = Stash::bufs[0].words;
+    Stash::load(WRITEBUF, 0);
+    uint16_t* segs = Stash::bufs[WRITEBUF].words;
 #ifdef __AVR__
     PGM_P fmt = (PGM_P) *++segs;
 #else
@@ -274,8 +288,8 @@ void Stash::extract (uint16_t offset, uint16_t count, void* buf) {
 }
 
 void Stash::cleanup () {
-    Stash::load(0, 0);
-    uint16_t* segs = Stash::bufs[0].words;
+    Stash::load(WRITEBUF, 0);
+    uint16_t* segs = Stash::bufs[WRITEBUF].words;
 #ifdef __AVR__
     PGM_P fmt = (PGM_P) *++segs;
 #else
@@ -391,7 +405,7 @@ uint8_t EtherCard::begin (const uint16_t size,
                           const uint8_t* macaddr,
                           uint8_t csPin) {
     using_dhcp = false;
-    Stash::initMap(56);
+    Stash::initMap();
     copyMac(mymac, macaddr);
     return initialize(size, mymac, csPin);
 }

--- a/EtherCard.cpp
+++ b/EtherCard.cpp
@@ -405,7 +405,9 @@ uint8_t EtherCard::begin (const uint16_t size,
                           const uint8_t* macaddr,
                           uint8_t csPin) {
     using_dhcp = false;
+#if ETHERCARD_STASH
     Stash::initMap();
+#endif
     copyMac(mymac, macaddr);
     return initialize(size, mymac, csPin);
 }

--- a/EtherCard.h
+++ b/EtherCard.h
@@ -71,10 +71,10 @@ class Stash : public /*Stream*/ Print, private StashHeader {
             uint8_t bytes[64];
             uint16_t words[32];
             struct {
-                StashHeader head;
+                StashHeader head; // StashHeader is only stored in first block 
                 uint8_t filler[59];
-                uint8_t tail;
-                uint8_t next;
+                uint8_t tail;     // only meaningful if bnum==last; number of bytes in last block 
+                uint8_t next;     // pointer to next block 
             };
         };
         uint8_t bnum;
@@ -85,10 +85,10 @@ class Stash : public /*Stream*/ Print, private StashHeader {
     static uint8_t fetchByte (uint8_t blk, uint8_t off);
 
     static Block bufs[2];
-    static uint8_t map[256/8];
+    static uint8_t map[SCRATCH_MAP_SIZE];
 
 public:
-    static void initMap (uint8_t last);
+    static void initMap (uint8_t last=SCRATCH_PAGE_NUM);
     static void load (uint8_t idx, uint8_t blk);
     static uint8_t freeCount ();
 

--- a/EtherCard.h
+++ b/EtherCard.h
@@ -18,6 +18,7 @@
 //   SI  - Pin 11
 //   CS  - Pin  8
 //
+/** @file */ 
 
 #ifndef EtherCard_h
 #define EtherCard_h
@@ -38,6 +39,50 @@
 #include <avr/pgmspace.h>
 #include "enc28j60.h"
 #include "net.h"
+
+/** Enable DHCP.
+*   Setting this to zero disables the use of DHCP; if a program uses DHCP it will
+*   still compile but the program will not work. Saves about 60 bytes SRAM and
+*   1550 bytes flash.
+*/
+#define ETHERCARD_DHCP 1
+
+/** Enable client connections.
+* Setting this to zero means that the program cannot issue TCP client requests
+* anymore. Compilation will still work but the request will never be
+* issued. Saves 4 bytes SRAM and 550 byte flash.
+*/
+#define ETHERCARD_TCPCLIENT 1
+
+/** Enable TCP server functionality. 
+*   Setting this to zero means that the program will not accept TCP client
+*   requests. Saves 2 bytes SRAM and 250 bytes flash.
+*/
+#define ETHERCARD_TCPSERVER 1
+
+/** Enable UDP server functionality. 
+*   If zero UDP server is disabled. It is
+*   still possible to register callbacks but these will never be called. Saves
+*   about 40 bytes SRAM and 200 bytes flash. If building with -flto this does not
+*   seem to save anything; maybe the linker is then smart enough to optimize the
+*   call away.
+*/
+#define ETHERCARD_UDPSERVER 1
+
+/** Enable automatic reply to pings.
+*   Setting to zero means that the program will not automatically answer to
+*   PINGs anymore. Also the callback that can be registered to answer incoming
+*   pings will not be called. Saves 2 bytes SRAM and 230 bytes flash.
+*/
+#define ETHERCARD_ICMP 1
+
+/** Enable use of stash.
+*   Setting this to zero means that the stash mechanism cannot be used. Again
+*   compilation will still work but the program may behave very unexpectedly.
+*   Saves 30 bytes SRAM and 80 bytes flash.
+*/
+#define ETHERCARD_STASH 1
+
 
 /** This type definition defines the structure of a UDP server event handler callback funtion */
 typedef void (*UdpServerCallback)(

--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -230,22 +230,7 @@ bool ENC28J60::promiscuous_enabled = false;
 #define ENC28J60_BIT_FIELD_CLR       0xA0
 #define ENC28J60_SOFT_RESET          0xFF
 
-// The RXSTART_INIT must be zero. See Rev. B4 Silicon Errata point 5.
-// Buffer boundaries applied to internal 8K ram
-// the entire available packet buffer space is allocated
-
-#define RXSTART_INIT        0x0000  // start of RX buffer, room for 2 packets
-#define RXSTOP_INIT         0x0BFF  // end of RX buffer
-
-#define TXSTART_INIT        0x0C00  // start of TX buffer, room for 1 packet
-#define TXSTOP_INIT         0x11FF  // end of TX buffer
-
-#define SCRATCH_START       0x1200  // start of scratch area
-#define SCRATCH_LIMIT       0x2000  // past end of area, i.e. 3.5 Kb
-#define SCRATCH_PAGE_SHIFT  6       // addressing is in pages of 64 bytes
-#define SCRATCH_PAGE_SIZE   (1 << SCRATCH_PAGE_SHIFT)
-
-// max frame length which the conroller will accept:
+// max frame length which the controller will accept:
 // (note: maximum ethernet frame length would be 1518)
 #define MAX_FRAMELEN      1500
 

--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -304,20 +304,42 @@ static void writeOp (byte op, byte address, byte data) {
 }
 
 static void readBuf(uint16_t len, byte* data) {
+    uint8_t nextbyte;
+
     enableChip();
-    xferSPI(ENC28J60_READ_BUF_MEM);
-    while (len--) {
-        xferSPI(0x00);
-        *data++ = SPDR;
+    if (len != 0) {    
+        xferSPI(ENC28J60_READ_BUF_MEM);
+          
+        SPDR = 0x00; 
+        while (--len) {
+            while (!(SPSR & (1<<SPIF)))
+                ;
+            nextbyte = SPDR;
+            SPDR = 0x00;
+            *data++ = nextbyte;     
+        }
+        while (!(SPSR & (1<<SPIF)))
+            ;
+        *data++ = SPDR;    
     }
-    disableChip();
+    disableChip(); 
 }
 
 static void writeBuf(uint16_t len, const byte* data) {
     enableChip();
-    xferSPI(ENC28J60_WRITE_BUF_MEM);
-    while (len--)
-        xferSPI(*data++);
+    if (len != 0) {
+        xferSPI(ENC28J60_WRITE_BUF_MEM);
+           
+        SPDR = *data++;    
+        while (--len) {
+            uint8_t nextbyte = *data++;
+        	while (!(SPSR & (1<<SPIF)))
+                ;
+            SPDR = nextbyte;
+     	};  
+        while (!(SPSR & (1<<SPIF)))
+            ;
+    }
     disableChip();
 }
 

--- a/enc28j60.h
+++ b/enc28j60.h
@@ -14,6 +14,23 @@
 #ifndef ENC28J60_H
 #define ENC28J60_H
 
+// buffer boundaries applied to internal 8K ram
+// the entire available packet buffer space is allocated
+
+#define RXSTART_INIT        0x0000  // start of RX buffer, (must be zero, Rev. B4 Errata point 5)
+#define RXSTOP_INIT         0x0BFF  // end of RX buffer, room for 2 packets
+ 
+#define TXSTART_INIT        0x0C00  // start of TX buffer, room for 1 packet
+#define TXSTOP_INIT         0x11FF  // end of TX buffer
+
+#define SCRATCH_START       0x1200  // start of scratch area
+#define SCRATCH_LIMIT       0x2000  // past end of area, i.e. 3 Kb
+#define SCRATCH_PAGE_SHIFT  6       // addressing is in pages of 64 bytes
+#define SCRATCH_PAGE_SIZE   (1 << SCRATCH_PAGE_SHIFT)
+#define SCRATCH_PAGE_NUM    ((SCRATCH_LIMIT-SCRATCH_START) >> SCRATCH_PAGE_SHIFT)
+#define SCRATCH_MAP_SIZE    (((SCRATCH_PAGE_NUM % 8) == 0) ? (SCRATCH_PAGE_NUM / 8) : (SCRATCH_PAGE_NUM/8+1))
+
+
 /** This class provide low-level interfacing with the ENC28J60 network interface. This is used by the EtherCard class and not intended for use by (normal) end users. */
 class ENC28J60 {
 public:


### PR DESCRIPTION
faster SPI block transfers
stash uses less SRAM
ifdefs allow to reduce functionality and thereby reduce code size

The new implementation of Stash::initMap(uint8_t) completely ignores 
the given parameter. This may look strange, but I actually do not see 
the reason for the parameter.
 