### PR TITLE
changes to receive large tcp replies 

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -627,6 +627,14 @@ public:
     */
     static void makeNetStr(char *resultstr,uint8_t *bytestr,uint8_t len,
                            char separator,uint8_t base);
+
+    /**   @brief  Return the sequence number of the current TCP package
+    */
+    static uint32_t getSequenceNumber();
+
+    /**   @brief  Return the payload length of the current Tcp package
+    */
+    static uint16_t getTcpPayloadLength(); 
 };
 
 extern EtherCard ether; //!< Global presentation of EtherCard class

--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -545,6 +545,7 @@ uint16_t ENC28J60::packetReceive() {
             writeReg(ERXRDPT, RXSTOP_INIT);
         else
             writeReg(ERXRDPT, gNextPacketPtr - 1);
+        unreleasedPacket = false;
     }
 
     if (readRegByte(EPKTCNT) > 0) {

--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -727,3 +727,26 @@ uint8_t ENC28J60::doBIST ( byte csPin) {
     return macResult == bitsResult;
 }
 
+
+void ENC28J60::memcpy_to_enc(uint16_t dest, void* source, int16_t num) {
+    writeReg(EWRPT, dest);
+    writeBuf(num, (uint8_t*) source);
+}
+
+void ENC28J60::memcpy_from_enc(void* dest, uint16_t source, int16_t num) {
+    writeReg(ERDPT, source);
+    readBuf(num, (uint8_t*) dest);
+}
+
+static uint16_t endRam = ENC_HEAP_END; 
+uint16_t ENC28J60::enc_malloc(uint16_t size) {
+    if (endRam-size >= ENC_HEAP_START) {
+        endRam -= size;
+        return endRam;
+    }
+    return 0;
+}
+
+uint16_t ENC28J60::enc_free() {
+    return endRam-ENC_HEAP_START;
+}

--- a/enc28j60.h
+++ b/enc28j60.h
@@ -30,6 +30,10 @@
 #define SCRATCH_PAGE_NUM    ((SCRATCH_LIMIT-SCRATCH_START) >> SCRATCH_PAGE_SHIFT)
 #define SCRATCH_MAP_SIZE    (((SCRATCH_PAGE_NUM % 8) == 0) ? (SCRATCH_PAGE_NUM / 8) : (SCRATCH_PAGE_NUM/8+1))
 
+// area in the enc memory that can be used via enc_malloc; by default 0 bytes; decrease SCRATCH_LIMIT in order
+// to use this functionality
+#define ENC_HEAP_START      SCRATCH_LIMIT
+#define ENC_HEAP_END        0x2000
 
 /** This class provide low-level interfacing with the ENC28J60 network interface. This is used by the EtherCard class and not intended for use by (normal) end users. */
 class ENC28J60 {
@@ -126,7 +130,7 @@ public:
     
     /**   @brief  Disable reception of all messages and go back to default mode
     *     @param  temporary Set true to only disable if temporarily enabled
-    *     @note   This will reduce load on recieved data handling
+    *     @note   This will reduce load on received data handling
     *     @note   In this mode only unicast and broadcast messages will be received
     */
     static void disablePromiscuous(bool temporary = false);
@@ -141,6 +145,34 @@ public:
     *     @return <i>uint8_t</i> 0 on failure
     */
     static uint8_t doBIST(uint8_t csPin = 8);
+
+    /** @brief  reserves a block of RAM in the memory of the enc chip
+     *  @param  size number of bytes to reserve
+     *  @return <i>uint16_t</i> start address of the block within the enc memory. 0 if the remaining memory for malloc operation is less than size.   
+     *  @note  There is no enc_free(), i.e., reserved blocks stay reserved for the duration of the program. 
+     *  @note  The total memory available for malloc-operations is determined by ENC_HEAP_END-ENC_HEAP_START, defined in enc28j60.h; by default this is 0, i.e., you have to change these values in order to use enc_malloc().  
+     */
+    static uint16_t enc_malloc(uint16_t size);
+
+    /** @brief  returns the amount of memory within the enc28j60 chip that is still available for malloc.
+     *  @return <i>uint16_t</i> the amount of memory in bytes.
+     */
+    static uint16_t enc_freemem();
+
+    /** @brief copies a block of data from SRAM to the enc memory
+        @param dest destination address within enc memory
+        @param source source pointer to a block of SRAM in the arduino
+        @param num number of bytes to copy
+        @note  There is no sanity check. Handle with care 
+     */
+    static void memcpy_to_enc(uint16_t dest, void* source, int16_t num);
+
+     /** @brief copies a block of data from the enc memory to SRAM
+        @param dest destination address within SRAM
+        @param source source address within enc memory
+        @param num number of bytes to copy
+     */
+    static void memcpy_from_enc(void* dest, uint16_t source, int16_t num);
 };
 
 typedef ENC28J60 Ethernet; //!< Define alias Ethernet for ENC28J60

--- a/enc28j60.h
+++ b/enc28j60.h
@@ -146,6 +146,15 @@ public:
     */
     static uint8_t doBIST(uint8_t csPin = 8);
 
+    /**   @brief  Copies a slice from the current packet to RAM
+    *     @param  dest pointer in RAM where the data is copied to
+    *     @param  maxlength how many bytes to copy; 
+    *     @param  packetOffset where within the packet to start; if less than maxlength bytes are available only the remaining bytes are copied.
+    *     @return <i>uint16_t</i> the number of bytes that have been read
+    *     @note   At the destination at least maxlength+1 bytes should be reserved because the copied content will be 0-terminated.
+    */                   
+    static uint16_t readPacketSlice(char* dest, int16_t maxlength, int16_t packetOffset);
+
     /** @brief  reserves a block of RAM in the memory of the enc chip
      *  @param  size number of bytes to reserve
      *  @return <i>uint16_t</i> start address of the block within the enc memory. 0 if the remaining memory for malloc operation is less than size.   

--- a/examples/persistence/persistence.ino
+++ b/examples/persistence/persistence.ino
@@ -1,0 +1,74 @@
+// Demo for using persistence flag and readPacketSlice()
+// http://opensource.org/licenses/mit-license.php
+
+#include <EtherCard.h>
+
+// ethernet interface mac address, must be unique on the LAN
+static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+
+// the buffersize must be relatively large for DHCP to work; when
+// using static setup a buffer size of 100 is sufficient;
+#define BUFFERSIZE 350
+byte Ethernet::buffer[BUFFERSIZE];
+
+const char website[] PROGMEM = "textfiles.com";
+
+uint32_t nextSeq;
+// called when the client request is complete
+static void my_callback (byte status, word off, word len) {
+   
+    if (strncmp_P((char*) Ethernet::buffer+off,PSTR("HTTP"),4) == 0) {
+        Serial.println(">>>");
+        // first reply packet
+        nextSeq = ether.getSequenceNumber();
+    }
+
+    if (nextSeq != ether.getSequenceNumber()) { Serial.print(F("<IGNORE DUPLICATE(?) PACKET>")); return; }
+    
+    uint16_t payloadlength = ether.getTcpPayloadLength();
+    int16_t chunk_size   = BUFFERSIZE-off-1;
+    int16_t char_written = 0;
+    int16_t char_in_buf  = chunk_size < payloadlength ? chunk_size : payloadlength;
+      
+    while (char_written < payloadlength) {
+        Serial.write((char*) Ethernet::buffer+off,char_in_buf);
+        char_written += char_in_buf;
+        
+        char_in_buf = ether.readPacketSlice((char*) Ethernet::buffer+off,chunk_size,off+char_written);
+    }
+    
+    nextSeq += ether.getTcpPayloadLength();
+}
+
+void setup () {
+    Serial.begin(57600);
+    Serial.println(F("\n[Persistence+readPacketSlice]"));
+
+  
+    if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+        Serial.println(F("Failed to access Ethernet controller"));
+    if (!ether.dhcpSetup())
+        Serial.println(F("DHCP failed"));
+
+    ether.printIp("IP:  ", ether.myip);
+    ether.printIp("GW:  ", ether.gwip);  
+    ether.printIp("DNS: ", ether.dnsip);  
+
+    if (!ether.dnsLookup(website))
+        Serial.println("DNS failed");
+    
+    ether.printIp("SRV: ", ether.hisip);
+    ether.persistTcpConnection(true);
+}
+
+void loop () {
+  ether.packetLoop(ether.packetReceive());
+  
+  static uint32_t timer =  0;
+  if (millis() > timer) {
+      timer = millis() + 7000;
+      Serial.println();
+      Serial.print("<<< REQ ");
+      ether.browseUrl(PSTR("/stories/"), "cmoutmou.txt", website, my_callback);
+  }
+}

--- a/tcpip.cpp
+++ b/tcpip.cpp
@@ -648,7 +648,8 @@ uint16_t EtherCard::accept(const uint16_t port, uint16_t plen) {
             if (info_data_len > 0)
             {   //Got some data
                 pos = TCP_DATA_START; // TCP_DATA_START is a formula
-                if (pos <= plen - 8)
+                //!@todo no idea what this check pos<=plen-8 does; changed this to pos<=plen as otw. perfectly valid tcp packets are ignored; still if anybody has any idea please leave a comment
+                if (pos <= plen) 
                     return pos;
             }
             else if (gPB[TCP_FLAGS_P] & TCP_FLAGS_FIN_V)


### PR DESCRIPTION
These changes enable support for handling large incoming tcp requests/replies that are larger
than the available buffer and/or consist of multiple packets. The new example file persistence.ino demonstrates the usage by printing an entire tcp reply using a relatively small buffer. 