### PR TITLE
update deprecated PGM_P types to "const char* PROGMEM"

### DIFF
--- a/EtherCard.cpp
+++ b/EtherCard.cpp
@@ -154,7 +154,7 @@ static char* wtoa (uint16_t value, char* ptr) {
 
 // write information about the fmt string and the arguments into special page/block 0    
 // block 0 is initially marked as allocated and never returned by allocateBlock 
-void Stash::prepare (PGM_P fmt, ...) {
+void Stash::prepare (const char* fmt PROGMEM, ...) {
     Stash::load(WRITEBUF, 0);
     uint16_t* segs = Stash::bufs[WRITEBUF].words;
     *segs++ = strlen_P(fmt);
@@ -187,7 +187,7 @@ void Stash::prepare (PGM_P fmt, ...) {
                 arglen = strlen((const char*) argval);
                 break;
             case 'F':
-                arglen = strlen_P((PGM_P) argval);
+                arglen = strlen_P((const char*) argval);
                 break;
             case 'E': {
                 byte* s = (byte*) argval;
@@ -223,9 +223,9 @@ void Stash::extract (uint16_t offset, uint16_t count, void* buf) {
     Stash::load(WRITEBUF, 0);
     uint16_t* segs = Stash::bufs[WRITEBUF].words;
 #ifdef __AVR__
-    PGM_P fmt = (PGM_P) *++segs;
+    const char* fmt PROGMEM = (const char*) *++segs;
 #else
-    PGM_P fmt = (PGM_P)((segs[2] << 16) | segs[1]);
+    const char* fmt PROGMEM = (const char*)((segs[2] << 16) | segs[1]);
     segs += 2;
 #endif
     Stash stash;
@@ -291,9 +291,9 @@ void Stash::cleanup () {
     Stash::load(WRITEBUF, 0);
     uint16_t* segs = Stash::bufs[WRITEBUF].words;
 #ifdef __AVR__
-    PGM_P fmt = (PGM_P) *++segs;
+    const char* fmt PROGMEM = (const char*) *++segs;
 #else
-    PGM_P fmt = (PGM_P)((segs[2] << 16) | segs[1]);
+    const char* fmt PROGMEM = (const char*)((segs[2] << 16) | segs[1]);
     segs += 2;
 #endif
     for (;;) {
@@ -315,7 +315,7 @@ void Stash::cleanup () {
     }
 }
 
-void BufferFiller::emit_p(PGM_P fmt, ...) {
+void BufferFiller::emit_p(const char* fmt PROGMEM, ...) {
     va_list ap;
     va_start(ap, fmt);
     for (;;) {
@@ -364,7 +364,7 @@ void BufferFiller::emit_p(PGM_P fmt, ...) {
             strcpy((char*) ptr, va_arg(ap, const char*));
             break;
         case 'F': {
-            PGM_P s = va_arg(ap, PGM_P);
+            const char* s PROGMEM = va_arg(ap, const char*);
             char d;
             while ((d = pgm_read_byte(s++)) != 0)
                 *ptr++ = d;

--- a/EtherCard.h
+++ b/EtherCard.h
@@ -168,7 +168,7 @@ public:
     //   offs = 63;
     // }
 
-    static void prepare (PGM_P fmt, ...);
+    static void prepare (const char* fmt PROGMEM, ...);
     static uint16_t length ();
     static void extract (uint16_t offset, uint16_t count, void* buf);
     static void cleanup ();
@@ -181,7 +181,7 @@ public:
 *
 *   This class provides formatted printing into memory. Users can use it to write into send buffers.
 *
-*   Nota: PGM_P: is a pointer to a string in program space (defined in the source code)
+*   Nota: PGM_P: is a pointer to a string in program space (defined in the source code, updated to PROGMEM)
 *
 *   # Format string
 *
@@ -237,7 +237,7 @@ public:
     *   @param  fmt Format string (see Class description)
     *   @param  ... parameters for format string
     */
-    void emit_p (PGM_P fmt, ...);
+    void emit_p (const char* fmt PROGMEM, ...);
 
     /** @brief  Add data to buffer from main memory
     *   @param  s Pointer to data
@@ -249,7 +249,7 @@ public:
     *   @param  p Program space string pointer
     *   @param  n Number of characters to copy
     */
-    void emit_raw_p (PGM_P p, uint16_t n) { memcpy_P(ptr, p, n); ptr += n; }
+    void emit_raw_p (const char* p PROGMEM, uint16_t n) { memcpy_P(ptr, p, n); ptr += n; }
 
     /** @brief  Get pointer to start of buffer
     *   @return <i>uint8_t*</i> Pointer to start of buffer

--- a/examples/noipClient/noipClient.ino
+++ b/examples/noipClient/noipClient.ino
@@ -274,6 +274,6 @@ void checkNoIPResponse() {
     }
 }
 
-void SerialPrint_P(PGM_P str) {
+void SerialPrint_P(const char* str PROGMEM) {
     for (uint8_t c; (c = pgm_read_byte(str)); str++) Serial.write(c);
 }


### PR DESCRIPTION
Update deprecated PGM_P types to remove compiler warnings, as suggested by @solarkennedy on the related issue.

Fixes #213