### PR TITLE
Replace Magic SPI SS number with define

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -293,7 +293,7 @@ public:
     *     @return <i>uint8_t</i> Firmware version or zero on failure.
     */
     static uint8_t begin (const uint16_t size, const uint8_t* macaddr,
-                          uint8_t csPin = PIN_SPI_SS);
+                          uint8_t csPin = SS);
 
     /**   @brief  Configure network interface with static IP
     *     @param  my_ip IP address (4 bytes). 0 for no change.

--- a/EtherCard.h
+++ b/EtherCard.h
@@ -270,7 +270,6 @@ public:
 /** This class provides the main interface to a ENC28J60 based network interface card and is the class most users will use.
 *   @note   All TCP/IP client (outgoing) connections are made from source port in range 2816-3071. Do not use these source ports for other purposes.
 */
-
 class EtherCard : public Ethernet {
 public:
     static uint8_t mymac[6];  ///< MAC address

--- a/EtherCard.h
+++ b/EtherCard.h
@@ -270,6 +270,7 @@ public:
 /** This class provides the main interface to a ENC28J60 based network interface card and is the class most users will use.
 *   @note   All TCP/IP client (outgoing) connections are made from source port in range 2816-3071. Do not use these source ports for other purposes.
 */
+
 class EtherCard : public Ethernet {
 public:
     static uint8_t mymac[6];  ///< MAC address
@@ -293,7 +294,7 @@ public:
     *     @return <i>uint8_t</i> Firmware version or zero on failure.
     */
     static uint8_t begin (const uint16_t size, const uint8_t* macaddr,
-                          uint8_t csPin =8);
+                          uint8_t csPin = PIN_SPI_SS);
 
     /**   @brief  Configure network interface with static IP
     *     @param  my_ip IP address (4 bytes). 0 for no change.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ See the comments in the example sketches for details about how to try them out.
     SO  - Pin 50
     SI  - Pin 51
     CS  - Pin 53 # Selectable with the ether.begin() function
-    # The default CS pin defaults to 8, so you have to set it on a mega:
-    ether.begin(sizeof Ethernet::buffer, mymac, 53)
 
 ## Support
 


### PR DESCRIPTION
Get SPI SS number from `pins_arduino.h` by using `PIN_SPI_SS` define and remove note about CS pin on Arduino Mega.