### PR TITLE
Add alternative to DNS lookup to webClient example

### DIFF
--- a/EtherCard.h
+++ b/EtherCard.h
@@ -531,6 +531,8 @@ public:
     static bool dhcpLease ();
 
     /**   @brief  Configure network interface with DHCP
+    *     @param  hname The hostname to pass to the DHCP server
+    *     @param  fromRam Set true to indicate whether hname is in RAM or in program space. Default = false
     *     @return <i>bool</i> True if DHCP successful
     *     @note   Blocks until DHCP complete or timeout after 60 seconds
     */
@@ -545,7 +547,7 @@ public:
     // dns.cpp
     /**   @brief  Perform DNS lookup
     *     @param  name Host name to lookup
-    *     @param  fromRam Set true to look up cached name. Default = false
+    *     @param  fromRam Set true to indicate whether name is in RAM or in program space. Default = false
     *     @return <i>bool</i> True on success.
     *     @note   Result is stored in <i>hisip</i> member
     */

--- a/examples/webClient/webClient.ino
+++ b/examples/webClient/webClient.ino
@@ -42,7 +42,7 @@ void setup () {
   char websiteIP[] = "192.168.1.1";
   ether.parseIp(ether.hisip, websiteIP);
 #else
-  // or provite a numeric IP address instead of a string
+  // or provide a numeric IP address instead of a string
   byte hisip[] = { 192,168,1,1 };
   ether.copyIp(ether.hisip, hisip);
 #endif

--- a/examples/webClient/webClient.ino
+++ b/examples/webClient/webClient.ino
@@ -32,8 +32,20 @@ void setup () {
   ether.printIp("GW:  ", ether.gwip);  
   ether.printIp("DNS: ", ether.dnsip);  
 
+#if 1
+  // use DNS to resolve the website's IP address
   if (!ether.dnsLookup(website))
     Serial.println("DNS failed");
+#elif 2
+  // if website is a string containing an IP address instead of a domain name,
+  // then use it directly. Note: the string can not be in PROGMEM.
+  char websiteIP[] = "192.168.1.1";
+  ether.parseIp(ether.hisip, websiteIP);
+#else
+  // or provite a numeric IP address instead of a string
+  byte hisip[] = { 192,168,1,1 };
+  ether.copyIp(ether.hisip, hisip);
+#endif
     
   ether.printIp("SRV: ", ether.hisip);
 }


### PR DESCRIPTION
* Explaining an alternative to DNS lookup somewhere in the examples will hopefully help future users avoid issues like #245 . 