### PR TITLE
Add ARP cache

### DIFF
--- a/src/EtherCard.h
+++ b/src/EtherCard.h
@@ -85,6 +85,11 @@
 */
 #define ETHERCARD_STASH 1
 
+/** Set ARP cache max entry count */
+#ifndef ETHERCARD_ARP_STORE_SIZE
+#   define ETHERCARD_ARP_STORE_SIZE 4
+#endif
+
 
 /** This type definition defines the structure of a UDP server event handler callback function */
 typedef void (*UdpServerCallback)(
@@ -189,6 +194,16 @@ public:
     /**   @brief  Updates the broadcast address based on current IP address and subnet mask
     */
     static void updateBroadcastAddress();
+
+    /**   @brief  Request the IP associated hardware address (ARP lookup). Use
+    *             clientWaitIp(ip) to get the ARP lookup status
+    */
+    static void clientResolveIp(const uint8_t *ip);
+
+    /**   @brief  Check if got IP associated hardware address (ARP lookup)
+    *     @return <i>unit8_t</i> True if gateway found
+    */
+    static uint8_t clientWaitIp(const uint8_t *ip);
 
     /**   @brief  Check if got gateway hardware address (ARP lookup)
     *     @return <i>unit8_t</i> True if gateway found
@@ -484,6 +499,33 @@ public:
     /**   @brief  Return the payload length of the current Tcp package
     */
     static uint16_t getTcpPayloadLength();
+
+    /**   @brief Check if IP is in ARP store
+    *     @param ip IP to check (size must be IP_LEN)
+    *     @return <i>bool</i> True if IP is in ARP store
+    */
+    static bool arpStoreHasMac(const uint8_t *ip);
+
+    /**   @brief convert IP into associated MAC address
+    *     @param ip IP to convert to MAC address (size must be IP_LEN)
+    *     @return <i>uint8_t *</i> mac MAC address or NULL if not found
+    */
+    static const uint8_t *arpStoreGetMac(const uint8_t *ip);
+
+    /**   @brief set/refresh new couple IP/MAC addresses into ARP store
+    *     @param ip IP address
+    *     @param mac MAC address
+    */
+    static void arpStoreSet(const uint8_t *ip, const uint8_t *mac);
+
+    /**   @brief remove IP from ARP store
+    *     @param ip IP address to remove
+    */
+    static void arpStoreInvalidIp(const uint8_t *ip);
+
+private:
+    static void packetLoopIdle();
+    static void packetLoopArp(const uint8_t *first, const uint8_t *last);
 };
 
 extern EtherCard ether; //!< Global presentation of EtherCard class

--- a/src/arp.cpp
+++ b/src/arp.cpp
@@ -1,0 +1,93 @@
+#include "EtherCard.h"
+
+struct ArpEntry
+{
+    uint8_t ip[IP_LEN];
+    uint8_t mac[ETH_LEN];
+    uint8_t count;
+};
+
+static ArpEntry store[ETHERCARD_ARP_STORE_SIZE];
+
+static void incArpEntry(ArpEntry &e)
+{
+    if (e.count < 0xFF)
+        ++e.count;
+}
+
+// static ArpEntry print_store()
+// {
+//     Serial.println("ARP store: ");
+//     for (ArpEntry *iter = store, *last = store + ETHERCARD_ARP_STORE_SIZE;
+//             iter != last; ++iter)
+//     {
+//         ArpEntry &e = *iter;
+//         Serial.print('\t');
+//         EtherCard::printIp(e.ip);
+//         Serial.print(' ');
+//         for (int i = 0; i < ETH_LEN; ++i)
+//         {
+//             if (i > 0)
+//                 Serial.print(':');
+//             Serial.print(e.mac[i], HEX);
+//         }
+//         Serial.print(' ');
+//         Serial.println(e.count);
+//     }
+// }
+
+static ArpEntry *findArpStoreEntry(const uint8_t *ip)
+{
+    for (ArpEntry *iter = store, *last = store + ETHERCARD_ARP_STORE_SIZE;
+            iter != last; ++iter)
+    {
+        if (memcmp(ip, iter->ip, IP_LEN) == 0)
+            return iter;
+    }
+    return NULL;
+}
+
+bool EtherCard::arpStoreHasMac(const uint8_t *ip)
+{
+    return findArpStoreEntry(ip) != NULL;
+}
+
+const uint8_t *EtherCard::arpStoreGetMac(const uint8_t *ip)
+{
+    ArpEntry *e = findArpStoreEntry(ip);
+    if (e)
+        return e->mac;
+    return NULL;
+}
+
+void EtherCard::arpStoreSet(const uint8_t *ip, const uint8_t *mac)
+{
+    ArpEntry *e = findArpStoreEntry(ip);
+    if (!e)
+    {
+        // find less used entry
+        e = store;
+        for (ArpEntry *iter = store + 1, *last = store + ETHERCARD_ARP_STORE_SIZE;
+                iter != last; ++iter)
+        {
+            if (iter->count < e->count)
+                e = iter;
+        }
+
+        // and replace it with new ip/mac
+        copyIp(e->ip, ip);
+        e->count = 1;
+    }
+    else
+        incArpEntry(*e);
+
+    copyMac(e->mac, mac);
+    // print_store();
+}
+
+void EtherCard::arpStoreInvalidIp(const uint8_t *ip)
+{
+    ArpEntry *e = findArpStoreEntry(ip);
+    if (e)
+        memset(e, 0, sizeof(ArpEntry));
+}


### PR DESCRIPTION
Pros:
 - keep MAC/IP relations into an ARP 'store'.
 - fix issue when IP packet is received from local network: answer is no more broadcasted
 - define ETHERCARD_ARP_STORE_SIZE to set cache size
 - Fix issue #181, issue #269 and issue #309 (Issues #181 and #309 looks to be the same)

Cons:
 - increase size of Ethercard in my project:
   - +198 bytes in `Program` section  (.text + .data + .bootloader)
   - +27 bytes in `Data` section (.data + .bss + .noinit)


About issue #269 the following code should be used:
```cpp
#define PORT 5000

#include <EtherCard.h>
#include <IPAddress.h>

uint8_t macAddr[] = {0x74,0x69,0x69,0x2D,0x30,0x32};
uint8_t ipAddr[] = { 192, 168, 1, 200 };
uint8_t gwAddr[] = { 192, 168, 1, 2 };
uint8_t netMask[] = { 255, 255, 255, 0 };

uint8_t distAddr[] = { 192, 168, 1, 52 }; // I can't send packet to 172.16.255.2.

byte Ethernet::buffer[256];

void setup() {
    Serial.begin(57600);
    ether.begin(sizeof(Ethernet::buffer), macAddr);
    ether.staticSetup(ipAddr, gwAddr, 0, netMask);

    // wait for link to be up before any ARP lookup
    while (!ether.isLinkUp())
        ;

    // send ARP lookup...
    ether.clientResolveIp(distAddr);
    // ...and wait for answer
    while (ether.clientWaitIp(distAddr))
        ether.packetLoop(ether.packetReceive());
    Serial.println("setup done");
}

void loop() {
    char c[] = { 'h', 'i' };
    ether.sendUdp(c, sizeof(c), PORT, distAddr, PORT);
    ether.packetLoop(ether.packetReceive());
    delay(1000);
}
```
