### PR TITLE
Exposed DHCP timeout in DHCP function as an optional parameter

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "EtherCard",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "keywords": "http, web, server, client, ethernet",
   "description": "EtherCard is an IPv4 driver for the ENC28J60 chip.",
   "homepage": "https://github.com/njh/EtherCard",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EtherCard
-version=1.1.0
+version=1.1.1
 author=Jean-Claude Wippler
 maintainer=Nicholas Humfrey
 sentence=EtherCard is an IPv4 driver for the ENC28J60 chip.

--- a/src/EtherCard.cpp
+++ b/src/EtherCard.cpp
@@ -30,7 +30,7 @@ uint16_t EtherCard::delaycnt = 0; //request gateway ARP lookup
 
 uint8_t EtherCard::begin (const uint16_t size,
                           const uint8_t* macaddr,
-                          uint8_t csPin, uint16_t timeout = 60000) {
+                          uint8_t csPin, uint16_t timeout) {
     using_dhcp = false;
 #if ETHERCARD_STASH
     Stash::initMap();

--- a/src/EtherCard.cpp
+++ b/src/EtherCard.cpp
@@ -30,7 +30,7 @@ uint16_t EtherCard::delaycnt = 0; //request gateway ARP lookup
 
 uint8_t EtherCard::begin (const uint16_t size,
                           const uint8_t* macaddr,
-                          uint8_t csPin) {
+                          uint8_t csPin, uint16_t timeout = 60000) {
     using_dhcp = false;
 #if ETHERCARD_STASH
     Stash::initMap();

--- a/src/EtherCard.cpp
+++ b/src/EtherCard.cpp
@@ -30,7 +30,7 @@ uint16_t EtherCard::delaycnt = 0; //request gateway ARP lookup
 
 uint8_t EtherCard::begin (const uint16_t size,
                           const uint8_t* macaddr,
-                          uint8_t csPin, uint16_t timeout) {
+                          uint8_t csPin) {
     using_dhcp = false;
 #if ETHERCARD_STASH
     Stash::initMap();

--- a/src/EtherCard.h
+++ b/src/EtherCard.h
@@ -128,7 +128,7 @@ public:
     *     @return <i>uint8_t</i> Firmware version or zero on failure.
     */
     static uint8_t begin (const uint16_t size, const uint8_t* macaddr,
-                          uint8_t csPin = SS, uint16_t timeout = 60000);
+                          uint8_t csPin = SS, uint16_t timeout);
 
     /**   @brief  Configure network interface with static IP
     *     @param  my_ip IP address (4 bytes). 0 for no change.

--- a/src/EtherCard.h
+++ b/src/EtherCard.h
@@ -128,7 +128,7 @@ public:
     *     @return <i>uint8_t</i> Firmware version or zero on failure.
     */
     static uint8_t begin (const uint16_t size, const uint8_t* macaddr,
-                          uint8_t csPin = SS);
+                          uint8_t csPin = SS, uint16_t timeout = 60000);
 
     /**   @brief  Configure network interface with static IP
     *     @param  my_ip IP address (4 bytes). 0 for no change.

--- a/src/EtherCard.h
+++ b/src/EtherCard.h
@@ -368,8 +368,8 @@ public:
     /**   @brief  Configure network interface with DHCP
     *     @param  hname The hostname to pass to the DHCP server
     *     @param  fromRam Set true to indicate whether hname is in RAM or in program space. Default = false
+    *     @param  timeout Time to wait before failing (default is 60 seconds)
     *     @return <i>bool</i> True if DHCP successful
-    *     @note   Blocks until DHCP complete or timeout after 60 seconds
     */
     static bool dhcpSetup (const char *hname = NULL, bool fromRam = false, uint16_t timeout = 60000);
 

--- a/src/EtherCard.h
+++ b/src/EtherCard.h
@@ -128,7 +128,7 @@ public:
     *     @return <i>uint8_t</i> Firmware version or zero on failure.
     */
     static uint8_t begin (const uint16_t size, const uint8_t* macaddr,
-                          uint8_t csPin = SS, uint16_t timeout = 60000);
+                          uint8_t csPin = SS);
 
     /**   @brief  Configure network interface with static IP
     *     @param  my_ip IP address (4 bytes). 0 for no change.
@@ -371,7 +371,7 @@ public:
     *     @return <i>bool</i> True if DHCP successful
     *     @note   Blocks until DHCP complete or timeout after 60 seconds
     */
-    static bool dhcpSetup (const char *hname = NULL, bool fromRam =false);
+    static bool dhcpSetup (const char *hname = NULL, bool fromRam = false, uint16_t timeout = 60000);
 
     /**   @brief  Register a callback for a specific DHCP option number
     *     @param  option The option number to request from the DHCP server

--- a/src/EtherCard.h
+++ b/src/EtherCard.h
@@ -128,7 +128,7 @@ public:
     *     @return <i>uint8_t</i> Firmware version or zero on failure.
     */
     static uint8_t begin (const uint16_t size, const uint8_t* macaddr,
-                          uint8_t csPin = SS, uint16_t timeout);
+                          uint8_t csPin = SS, uint16_t timeout = 60000);
 
     /**   @brief  Configure network interface with static IP
     *     @param  my_ip IP address (4 bytes). 0 for no change.

--- a/src/dhcp.cpp
+++ b/src/dhcp.cpp
@@ -332,7 +332,7 @@ static char toAsciiHex(byte b) {
     return c;
 }
 
-bool EtherCard::dhcpSetup (const char *hname, bool fromRam) {
+bool EtherCard::dhcpSetup (const char *hname, bool fromRam, uint16_t timeout = 60000) {
     // Use during setup, as this discards all incoming requests until it returns.
     // That shouldn't be a problem, because we don't have an IPaddress yet.
     // Will try 60 secs to obtain DHCP-lease.
@@ -356,7 +356,7 @@ bool EtherCard::dhcpSetup (const char *hname, bool fromRam) {
     dhcpState = DHCP_STATE_INIT;
     uint16_t start = millis();
 
-    while (dhcpState != DHCP_STATE_BOUND && uint16_t(millis()) - start < 60000) {
+    while (dhcpState != DHCP_STATE_BOUND && uint16_t(millis()) - start < timeout) {
         if (isLinkUp()) DhcpStateMachine(packetReceive());
     }
     updateBroadcastAddress();

--- a/src/dhcp.cpp
+++ b/src/dhcp.cpp
@@ -332,7 +332,7 @@ static char toAsciiHex(byte b) {
     return c;
 }
 
-bool EtherCard::dhcpSetup (const char *hname, bool fromRam, uint16_t timeout = 60000) {
+bool EtherCard::dhcpSetup (const char *hname, bool fromRam, uint16_t timeout) {
     // Use during setup, as this discards all incoming requests until it returns.
     // That shouldn't be a problem, because we don't have an IPaddress yet.
     // Will try 60 secs to obtain DHCP-lease.


### PR DESCRIPTION
Added a configurable timeout to the DHCP setup funtion in order to make the timeout optionally configurable.
Fixes #359