### PR TITLE
Consistent comment style and bugfix in examples/webClient/webClient.ino

### DIFF
--- a/examples/JeeUdp/JeeUdp.ino
+++ b/examples/JeeUdp/JeeUdp.ino
@@ -24,14 +24,14 @@ struct Config {
   byte valid; // keep this as last byte
 } config;
 
-// ethernet interface mac address - must be unique on your network
+// Ethernet interface MAC address - must be unique on your network
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
-// buffer for an outgoing data packet
+// Buffer for an outgoing data packet
 static byte outBuf[RF12_MAXDATA], outDest;
 static char outCount = -1;
 
-// this buffer will be used to construct a collectd UDP packet
+// This buffer will be used to construct a collectd UDP packet
 static byte collBuf [200], collPos;
 
 #define NUM_MESSAGES  3     // Number of messages saved in history
@@ -39,12 +39,12 @@ static byte collBuf [200], collPos;
 
 static BufferFiller bfill;  // used as cursor while filling the buffer
 
-static byte history_rcvd[NUM_MESSAGES][MESSAGE_TRUNC+1]; //history record
-static byte history_len[NUM_MESSAGES]; // # of RF12 messages+header in history
-static byte next_msg;       // pointer to next rf12rcvd line
-static word msgs_rcvd;      // total number of lines received modulo 10,000
+static byte history_rcvd[NUM_MESSAGES][MESSAGE_TRUNC+1]; // history record
+static byte history_len[NUM_MESSAGES];                   // # of RF12 messages+header in history
+static byte next_msg;                                    // pointer to next rf12rcvd line
+static word msgs_rcvd;                                   // total number of lines received modulo 10,000
 
-byte Ethernet::buffer[700];   // tcp/ip send and receive buffer
+byte Ethernet::buffer[700];   // TCP/IP send and receive buffer
 
 static void loadConfig () {
   for (byte i = 0; i < sizeof config; ++i)
@@ -93,7 +93,7 @@ static void homePage (BufferFiller& buf) {
     byte j = (next_msg + i) % NUM_MESSAGES;
     if (history_len[j] > 0) {
       word n = msgs_rcvd - NUM_MESSAGES + i;
-      buf.emit_p(PSTR("\n$D$D$D$D: OK"), // hack, to show leading zero's
+      buf.emit_p(PSTR("\n$D$D$D$D: OK"), // hack, to show leading zeroes
                           n/1000, (n/100) % 10, (n/10) % 10, n % 10);
       for (byte k = 0; k < history_len[j]; ++k)
         buf.emit_p(PSTR(" $D"), history_rcvd[j][k]);
@@ -119,24 +119,24 @@ static int getIntArg(const char* data, const char* key, int value =-1) {
 }
 
 static void configPage (const char* data, BufferFiller& buf) {
-  // pick up submitted data, if present
+  // Pick up submitted data if present
   if (data[6] == '?') {
     byte b = getIntArg(data, "b", 8);
     byte g = getIntArg(data, "g", 1);
     byte c = getIntArg(data, "c", 0);
     word p = getIntArg(data, "p", 25827);
     if (1 <= g && g <= 250 && 1024 <= p && p <= 30000) {
-      // store values as new settings
+      // Store values as new settings
       config.band = b;
       config.group = g;
       config.collect = c;
       config.port = p;
       saveConfig();
-      // re-init RF12 driver
+      // Re-init RF12 driver
       loadConfig();
-      // clear history
+      // Clear history
       memset(history_len, 0, sizeof history_len);
-      // redirect to the home page
+      // Redirect to the home page
       buf.emit_p(PSTR(
         "HTTP/1.0 302 found\r\n"
         "Location: /\r\n"
@@ -144,7 +144,7 @@ static void configPage (const char* data, BufferFiller& buf) {
       return;
     }
   }
-  // else show a configuration form
+  // Else show a configuration form
   buf.emit_p(PSTR("$F\r\n"
     "<h3>Server node configuration</h3>"
     "<form>"
@@ -162,14 +162,14 @@ static void configPage (const char* data, BufferFiller& buf) {
 }
 
 static void sendPage (const char* data, BufferFiller& buf) {
-  // pick up submitted data, if present
+  // Pick up submitted data, if present
   const char* p = strstr(data, "b=");
   byte d = getIntArg(data, "d");
   if (data[6] == '?' && p != 0 && 0 <= d && d <= 31) {
-    // prepare to send data as soon as possible in loop()
+    // Prepare to send data as soon as possible in loop()
     outDest = d & RF12_HDR_MASK ? RF12_HDR_DST | d : 0;
     outCount = 0;
-    // convert the input string to a number of decimal data bytes in outBuf
+    // Convert the input string to a number of decimal data bytes in outBuf
     ++p;
     while (*p != 0 && *p != '&') {
       outBuf[outCount] = 0;
@@ -187,14 +187,14 @@ static void sendPage (const char* data, BufferFiller& buf) {
     }
     Serial.println();
 #endif
-    // redirect to home page
+    // Redirect to home page
     buf.emit_p(PSTR(
       "HTTP/1.0 302 found\r\n"
       "Location: /\r\n"
       "\r\n"));
     return;
   }
-  // else show a send form
+  // Else show a send form
   buf.emit_p(PSTR("$F\r\n"
     "<h3>Send a wireless data packet</h3>"
     "<form>"
@@ -260,7 +260,7 @@ void setup (){
   Serial.println("\n[JeeUdp]");
   loadConfig();
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println( "Failed to access Ethernet controller");
   if (!ether.dhcpSetup())
@@ -271,14 +271,14 @@ void setup (){
 void loop (){
   word len = ether.packetReceive();
   word pos = ether.packetLoop(len);
-  // check if valid tcp data is received
+  // Check if valid TCP data is received
   if (pos) {
     bfill = ether.tcpOffset();
     char* data = (char *) Ethernet::buffer + pos;
 #if SERIAL
     Serial.println(data);
 #endif
-    // receive buf hasn't been clobbered by reply yet
+    // Receive buf hasn't been clobbered by reply yet
     if (strncmp("GET / ", data, 6) == 0)
       homePage(bfill);
     else if (strncmp("GET /c", data, 6) == 0)
@@ -294,7 +294,7 @@ void loop (){
     ether.httpServerReply(bfill.position()); // send web page data
   }
 
-  // RFM12 loop runner, don't report acks
+  // RFM12 loop runner, don't report ACKs
   if (rf12_recvDone() && rf12_crc == 0 && (rf12_hdr & RF12_HDR_CTL) == 0) {
     history_rcvd[next_msg][0] = rf12_hdr;
     for (byte i = 0; i < rf12_len; ++i)
@@ -315,7 +315,7 @@ void loop (){
     forwardToUDP();
   }
 
-  // send a data packet out if requested
+  // Send a data packet out if requested
   if (outCount >= 0 && rf12_canSend()) {
     rf12_sendStart(outDest, outBuf, outCount);
     rf12_sendWait(1);

--- a/examples/SSDP/SSDP.ino
+++ b/examples/SSDP/SSDP.ino
@@ -1,17 +1,17 @@
 #include <EtherCard.h>//                                                                                                                                    |Mac adress|
-const char SSDP_RESPONSE[] PROGMEM = "HTTP/1.1 200 OK\r\nCACHE-CONTROL: max-age=1200\r\nEXT:\r\nSERVER:Arduino\r\nST: upnp:rootdevice\r\nUSN: uuid:abcdefgh-7dec-11d0-a765-7499692d3040\r\nLOCATION: http://"; //dont forget our mac adress USN: uuid:abcdefgh-7dec-11d0-a765-Mac addr
-const char SSDP_RESPONSE_XML[] PROGMEM = "/??\r\n\r\n"; // here is the adress of xml file /?? in this exemple but you could use another /upnp.xml\r\n\r\n
+const char SSDP_RESPONSE[] PROGMEM = "HTTP/1.1 200 OK\r\nCACHE-CONTROL: max-age=1200\r\nEXT:\r\nSERVER:Arduino\r\nST: upnp:rootdevice\r\nUSN: uuid:abcdefgh-7dec-11d0-a765-7499692d3040\r\nLOCATION: http://"; // don't forget our MAC adress USN: uuid:abcdefgh-7dec-11d0-a765-Mac addr
+const char SSDP_RESPONSE_XML[] PROGMEM = "/??\r\n\r\n"; // Here is the address of xml file /?? in this exemple but you could use another /upnp.xml\r\n\r\n
 const char XML_DESCRIP[] PROGMEM = "HTTP/1.1 200 OK\r\nContent-Type: text/xml\r\n\r\n<?xml version='1.0'?>\r<root xmlns='urn:schemas-upnp-org:device-1-0'><device><deviceType>urn:schemas-upnp-org:device:BinaryLight:1</deviceType><presentationURL>/</presentationURL><friendlyName>Arduino</friendlyName><manufacturer>Fredycpu</manufacturer><manufacturerURL>http://fredycpu.pro</manufacturerURL><serialNumber>1</serialNumber><UDN>uuid:abcdefgh-7dec-11d0-a765-7499692d3040</UDN></device></root>     ";
-const char SSDP_NOTIFY[] PROGMEM = "NOTIFY * HTTP/1.1\r\nHOST: 239.255.255.250:1900\r\nCACHE-CONTROL: max-age=1200\r\nNT: upnp:rootdevice\r\nUSN: uuid:abcdefga-7dec-11d0-a765-7499692d3040::upnp:rootdevice\r\nNTS: ssdp:alive\r\nSERVER: Arduino UPnP/1.0\r\nLOCATION: http://"; //dont forget our mac adress USN: uuid:abcdefgh-7dec-11d0-a765-Mac addr
+const char SSDP_NOTIFY[] PROGMEM = "NOTIFY * HTTP/1.1\r\nHOST: 239.255.255.250:1900\r\nCACHE-CONTROL: max-age=1200\r\nNT: upnp:rootdevice\r\nUSN: uuid:abcdefga-7dec-11d0-a765-7499692d3040::upnp:rootdevice\r\nNTS: ssdp:alive\r\nSERVER: Arduino UPnP/1.0\r\nLOCATION: http://"; // don't forget our MAC adress USN: uuid:abcdefgh-7dec-11d0-a765-Mac addr
 //  in XML_DESCRIP // <deviceType>urn:schemas-upnp-org:device:BinaryLight:1</deviceType> // declare as home automation
 //  in XML_DESCRIP // <friendlyName>Arduino</friendlyName> // declare the name of the service here Arduino
-//  in XML_DESCRIP // <presentationURL>/</presentationURL> // adress of the page who would opened on service double click ,you could use http://ip  but if you use dhcp it's better so and dont wase memory
-// this is the entire protocol, but you can try to use SSDP_NOTIFY as SSDP_RESPONSE with most systems will work and you can free a bit of flash mem.
+//  in XML_DESCRIP // <presentationURL>/</presentationURL> // address of the page who would opened on service double click, you could use http://ip  but if you use DHCP, it's better so and doesn't waste memory
+// This is the entire protocol, but you can try to use SSDP_NOTIFY as SSDP_RESPONSE; with most systems, this will work and you can free a bit of flash mem.
 static byte myip[] = { 192,168,0,67 };
 static byte gwip[] = { 192,168,0,250 };
 static byte ssdp[] = { 239,255,255,250 };
-static byte mymac[] = { 0x74,0x99,0x69,0x2D,0x30,0x40 }; // if you change it you must update SSDP_RESPONSE and XML_DESCRIP
-byte Ethernet::buffer[750]; // tcp ip send and receive buffer
+static byte mymac[] = { 0x74,0x99,0x69,0x2D,0x30,0x40 }; // if you change it, you must update SSDP_RESPONSE and XML_DESCRIP
+byte Ethernet::buffer[750]; // TCP/IP send and receive buffer
 unsigned long timer=9999;
 const char pageA[] PROGMEM =
 "HTTP/1.0 200 OK\r\n"
@@ -50,8 +50,8 @@ const char pageD[] PROGMEM =
 
 void ssdpresp() { //response to m-search
   byte ip_dst[IP_LEN];
-  unsigned int port_dst=Ethernet::buffer[34]*256+Ethernet::buffer[35];//extract source port of request
-  for(  int i=0; i<IP_LEN;i++) { //extract source IP of request
+  unsigned int port_dst=Ethernet::buffer[34]*256+Ethernet::buffer[35]; // extract source port of request
+  for (int i=0; i<IP_LEN;i++) { // extract source IP of request
     ip_dst[i]=Ethernet::buffer[i+26];
   }
   int udppos = UDP_DATA_P;
@@ -66,49 +66,49 @@ void ssdpnotify() { //Notification
   int udppos = UDP_DATA_P;
   EtherCard::udpPrepare(1900,ssdp,1900);
   memcpy_P(Ethernet::buffer + udppos, SSDP_NOTIFY, sizeof SSDP_NOTIFY);
-udppos = udppos  + sizeof SSDP_NOTIFY-1;
-addip(udppos);
+  udppos = udppos  + sizeof SSDP_NOTIFY-1;
+  addip(udppos);
 }
 
-void addip(int udppos) { // add current ip to the request and send it
+void addip(int udppos) { // add current IP to the request and send it
   int adr;
-  for(int i=0;i<IP_LEN;i++) { // extract the current ip of arduino
+  for (int i=0;i<IP_LEN;i++) { // extract the current IP of arduino
     adr = ether.myip[i]/100;
-    if (adr)  {
-      Ethernet::buffer[udppos]=adr+48;
+    if (adr) {
+      Ethernet::buffer[udppos] = adr+48;
       udppos++;
     }
     adr=(ether.myip[i]%100)/10;
     if (adr||(ether.myip[i]/100))  {
-      Ethernet::buffer[udppos]=adr+48;
+      Ethernet::buffer[udppos] = adr+48;
       udppos++;
     }
     adr=ether.myip[i]%10;
-    Ethernet::buffer[udppos]=adr+48;
+    Ethernet::buffer[udppos] = adr+48;
     udppos++;
-    Ethernet::buffer[udppos]=46;
-    udppos++; //"."
+    Ethernet::buffer[udppos] = 46;
+    udppos++; // "."
   }
-  udppos--;//erase the last point
+  udppos--; // erase the last point
   memcpy_P(Ethernet::buffer + udppos,SSDP_RESPONSE_XML,sizeof SSDP_RESPONSE_XML);
   udppos = udppos  + sizeof SSDP_RESPONSE_XML;
   udppos--;
-  EtherCard::udpTransmit(udppos-UDP_DATA_P); // send all to the computer who make the request on her ip and port who make the request
+  EtherCard::udpTransmit(udppos-UDP_DATA_P); // send all to the computer who make the request on her IP and port who make the request
 }
 
 
 void setup(){
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   ether.begin(sizeof Ethernet::buffer, mymac, SS);
   ether.staticSetup(myip, gwip);
-  ENC28J60::disableMulticast(); //disable multicast filter means enable multicast reception
+  ENC28J60::disableMulticast(); // disable multicast filter means enable multicast reception
   Serial.begin(115200);
 }
 
 void loop(){
 wait:
   word pos = ether.packetLoop(ether.packetReceive());
-  // check if valid tcp data is received
+  // check if valid TCP data is received
   if (pos) {
     char* data = (char *) Ethernet::buffer + pos;
     if (strncmp("GET / ", data, 6) == 0) {
@@ -123,13 +123,13 @@ wait:
       ether.httpServerReply_with_flags(sizeof pageD - 1,TCP_FLAGS_ACK_V|TCP_FLAGS_FIN_V);
       goto wait;
     }
-    if (strncmp("GET /??", data, 7) == 0) { // description of services (normaly an xml file but here .....)
+    if (strncmp("GET /??", data, 7) == 0) { // description of services (normaly an XML file, but here .....)
       ether.httpServerReplyAck();
       memcpy_P(Ethernet::buffer + TCP_OPTIONS_P,XML_DESCRIP, sizeof XML_DESCRIP);
       ether.httpServerReply_with_flags(sizeof XML_DESCRIP - 1 ,TCP_FLAGS_ACK_V|TCP_FLAGS_FIN_V);
       goto wait;
     }
-    if (strncmp("M-SEARCH", data, 8) == 0) { // service discovery request comes here (udp protocol)
+    if (strncmp("M-SEARCH", data, 8) == 0) { // service discovery request comes here (UDP protocol)
       ssdpresp();
       goto wait;
     }

--- a/examples/backSoon/backSoon.ino
+++ b/examples/backSoon/backSoon.ino
@@ -5,19 +5,19 @@
 
 #include <EtherCard.h>
 
-#define STATIC 0  // set to 1 to disable DHCP (adjust myip/gwip values below)
+#define STATIC 0  // Set to 1 to disable DHCP (adjust myip/gwip values below)
 
 #if STATIC
-// ethernet interface ip address
+// Ethernet interface IP address
 static byte myip[] = { 192,168,1,200 };
-// gateway ip address
+// Gateway IP address
 static byte gwip[] = { 192,168,1,1 };
 #endif
 
-// ethernet mac address - must be unique on your network
+// Ethernet MAC address - must be unique on your network
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
-byte Ethernet::buffer[500]; // tcp/ip send and receive buffer
+byte Ethernet::buffer[500]; // TCP/IP send and receive buffer
 
 const char page[] PROGMEM =
 "HTTP/1.0 503 Service Unavailable\r\n"
@@ -42,7 +42,7 @@ void setup(){
   Serial.begin(57600);
   Serial.println("\n[backSoon]");
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin, if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println( "Failed to access Ethernet controller");
 #if STATIC
@@ -58,7 +58,7 @@ void setup(){
 }
 
 void loop(){
-  // wait for an incoming TCP packet, but ignore its contents
+  // Wait for an incoming TCP packet, but ignore its contents
   if (ether.packetLoop(ether.packetReceive())) {
     memcpy_P(ether.tcpOffset(), page, sizeof page);
     ether.httpServerReply(sizeof page - 1);

--- a/examples/getDHCPandDNS/getDHCPandDNS.ino
+++ b/examples/getDHCPandDNS/getDHCPandDNS.ino
@@ -7,15 +7,15 @@
 
 #define REQUEST_RATE 5000 // milliseconds
 
-// ethernet interface mac address
+// Ethernet interface MAC address
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
-// remote website name
+// Remote website name
 const char website[] PROGMEM = "google.com";
 
 byte Ethernet::buffer[700];
 static long timer;
 
-// called when the client request is complete
+// Called when the client request is complete
 static void my_result_cb (byte status, word off, word len) {
   Serial.print("<<< reply ");
   Serial.print(millis() - timer);
@@ -27,7 +27,7 @@ void setup () {
   Serial.begin(57600);
   Serial.println("\n[getDHCPandDNS]");
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println( "Failed to access Ethernet controller");
 

--- a/examples/getStaticIP/getStaticIP.ino
+++ b/examples/getStaticIP/getStaticIP.ino
@@ -7,23 +7,23 @@
 
 #define REQUEST_RATE 5000 // milliseconds
 
-// ethernet interface mac address
+// Ethernet interface MAC address
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
-// ethernet interface ip address
+// Ethernet interface IP address
 static byte myip[] = { 192,168,1,203 };
-// ethernet interface ip netmask
+// Ethernet interface IP netmask
 static byte mask[] = { 255,255,255,0 };
-// gateway ip address
+// Gateway IP address
 static byte gwip[] = { 192,168,1,1 };
-// remote website ip address and port
+// Remote website IP address and port
 static byte hisip[] = { 74,125,79,99 };
-// remote website name
+// Remote website name
 const char website[] PROGMEM = "google.com";
 
-byte Ethernet::buffer[300];   // a very small tcp/ip buffer is enough here
+byte Ethernet::buffer[300];   // a very small TCP/IP buffer is enough here
 static long timer;
 
-// called when the client request is complete
+// Called when the client request is complete
 static void my_result_cb (byte status, word off, word len) {
   Serial.print("<<< reply ");
   Serial.print(millis() - timer);
@@ -35,7 +35,7 @@ void setup () {
   Serial.begin(57600);
   Serial.println("\n[getStaticIP]");
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println( "Failed to access Ethernet controller");
 

--- a/examples/getViaDNS/getViaDNS.ino
+++ b/examples/getViaDNS/getViaDNS.ino
@@ -7,21 +7,21 @@
 
 #define REQUEST_RATE 5000 // milliseconds
 
-// ethernet interface mac address
+// Ethernet interface MAC address
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
-// ethernet interface ip address
+// Ethernet interface IP address
 static byte myip[] = { 192,168,1,203 };
-// ethernet interface ip netmask
+// Ethernet interface IP netmask
 static byte mask[] = { 255,255,255,0 };
-// gateway ip address
+// Gateway IP address
 static byte gwip[] = { 192,168,1,1 };
-// remote website name
+// Remote website name
 const char website[] PROGMEM = "google.com";
 
-byte Ethernet::buffer[300];   // a very small tcp/ip buffer is enough here
+byte Ethernet::buffer[300];   // a very small TCP/IP buffer is enough here
 static long timer;
 
-// called when the client request is complete
+// Called when the client request is complete
 static void my_result_cb (byte status, word off, word len) {
   Serial.print("<<< reply ");
   Serial.print(millis() - timer);
@@ -33,7 +33,7 @@ void setup () {
   Serial.begin(57600);
   Serial.println("\n[getViaDNS]");
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println( "Failed to access Ethernet controller");
 

--- a/examples/multipacket/multipacket.ino
+++ b/examples/multipacket/multipacket.ino
@@ -1,10 +1,10 @@
 #include <EtherCard.h>
-#define TCP_FLAGS_FIN_V 1 //as declared in net.h
-#define TCP_FLAGS_ACK_V 0x10 //as declared in net.h
+#define TCP_FLAGS_FIN_V 1    // as declared in net.h
+#define TCP_FLAGS_ACK_V 0x10 // as declared in net.h
 static byte myip[] = { 192,168,0,66 };
 static byte gwip[] = { 192,168,0,250 };
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x39 };
-byte Ethernet::buffer[900]; // tcp ip send and receive buffer
+byte Ethernet::buffer[900]; // TCP/IP send and receive buffer
 const char pageA[] PROGMEM =
 "HTTP/1.0 200 OK\r\n"
 "Content-Type: text/html\r\n"
@@ -47,18 +47,18 @@ const char pageE[] PROGMEM =
 
 
 void setup(){
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   ether.begin(sizeof Ethernet::buffer, mymac , SS);
   ether.staticSetup(myip, gwip);
 }
 
 void loop(){
     word pos = ether.packetLoop(ether.packetReceive());
-    // check if valid tcp data is received
+    // check if valid TCP data is received
     if (pos) {
         char* data = (char *) Ethernet::buffer + pos;
         if (strncmp("GET / ", data, 6) == 0) {
-            ether.httpServerReplyAck(); // send ack to the request
+            ether.httpServerReplyAck(); // send ACK to the request
             memcpy_P(ether.tcpOffset(), pageA, sizeof pageA); // send first packet and not send the terminate flag
             ether.httpServerReply_with_flags(sizeof pageA - 1,TCP_FLAGS_ACK_V);
             memcpy_P(ether.tcpOffset(), pageB, sizeof pageB); // send second packet and not send the terminate flag
@@ -71,8 +71,8 @@ void loop(){
             ether.httpServerReply_with_flags(sizeof pageE - 1,TCP_FLAGS_ACK_V|TCP_FLAGS_FIN_V); }
         else
         {
-            ether.httpServerReplyAck(); // send ack to the request
-            memcpy_P(ether.tcpOffset(), pageA, sizeof pageA);//only the first part will sended
+            ether.httpServerReplyAck();                       // send ACK to the request
+            memcpy_P(ether.tcpOffset(), pageA, sizeof pageA); // only the first part will sent
             ether.httpServerReply_with_flags(sizeof pageA - 1,TCP_FLAGS_ACK_V|TCP_FLAGS_FIN_V);
         }
   }

--- a/examples/nanether/nanether.ino
+++ b/examples/nanether/nanether.ino
@@ -23,7 +23,7 @@ void setup(void)
     /* Check that the Ethernet controller exists */
     Serial.println("Initialising the Ethernet controller");
 
-    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+    // Change 'SS' to your Slave Select pin if you aren't using the default pin
     if (ether.begin(sizeof Ethernet::buffer, mac, SS) == 0) {
         Serial.println( "Ethernet controller NOT initialised");
         while (true)

--- a/examples/noipClient/noipClient.ino
+++ b/examples/noipClient/noipClient.ino
@@ -212,7 +212,7 @@ void setup () {
     Serial.println(F("NoIP Client Demo"));
     Serial.println();
 
-    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+    // Change 'SS' to your Slave Select pin if you aren't using the default pin
     if (!ether.begin(sizeof Ethernet::buffer, mymac, SS))
         Serial.println(F( "Failed to access Ethernet controller"));
     else

--- a/examples/notifyMyAndroid/notifyMyAndroid.ino
+++ b/examples/notifyMyAndroid/notifyMyAndroid.ino
@@ -58,7 +58,7 @@ void setup () {
   Serial.begin(57600);
   Serial.println("\nStarting Notify My Android Example");
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())

--- a/examples/ntpClient/ntpClient.ino
+++ b/examples/ntpClient/ntpClient.ino
@@ -17,7 +17,7 @@
 
 #include <EtherCard.h>  // https://github.com/njh/EtherCard
 
-// Ethernet mac address - must be unique on your network
+// Ethernet MAC address - must be unique on your network
 const byte myMac[] PROGMEM = { 0x70, 0x69, 0x69, 0x2D, 0x30, 0x31 };
 const char NTP_REMOTEHOST[] PROGMEM = "ntp.bit.nl";  // NTP server name
 const unsigned int NTP_REMOTEPORT = 123;             // NTP requests are to port 123
@@ -25,7 +25,7 @@ const unsigned int NTP_LOCALPORT = 8888;             // Local UDP port to use
 const unsigned int NTP_PACKET_SIZE = 48;             // NTP time stamp is in the first 48 bytes of the message
 byte Ethernet::buffer[350];                          // Buffer must be 350 for DHCP to work
 
-// send an NTP request to the time server at the given address
+// Send an NTP request to the time server at the given address
 void sendNTPpacket(const uint8_t* remoteAddress) {
   // buffer to hold outgoing packet
   byte packetBuffer[ NTP_PACKET_SIZE];
@@ -43,7 +43,7 @@ void sendNTPpacket(const uint8_t* remoteAddress) {
   packetBuffer[14]  = 49;
   packetBuffer[15]  = 52;
 
-  // all NTP fields have been given values, now
+  // All NTP fields have been given values, now
   // you can send a packet requesting a timestamp:
   ether.sendUdp(packetBuffer, NTP_PACKET_SIZE, NTP_LOCALPORT, remoteAddress, NTP_REMOTEPORT );
   Serial.println("NTP request sent.");
@@ -52,19 +52,19 @@ void sendNTPpacket(const uint8_t* remoteAddress) {
 void udpReceiveNtpPacket(uint16_t dest_port, uint8_t src_ip[IP_LEN], uint16_t src_port, const char *packetBuffer, uint16_t len) {
   Serial.println("NTP response received.");
 
-  // the timestamp starts at byte 40 of the received packet and is four bytes,
+  // The timestamp starts at byte 40 of the received packet and is four bytes,
   // or two words, long. First, extract the two words:
   unsigned long highWord = word(packetBuffer[40], packetBuffer[41]);
   unsigned long lowWord = word(packetBuffer[42], packetBuffer[43]);
-  // combine the four bytes (two words) into a long integer
+  // Combine the four bytes (two words) into a long integer
   // this is NTP time (seconds since Jan 1 1900):
   unsigned long secsSince1900 = highWord << 16 | lowWord;
   // Unix time starts on Jan 1 1970. In seconds, that's 2208988800:
   const unsigned long seventyYears = 2208988800UL;
-  // subtract seventy years:
+  // Subtract seventy years:
   unsigned long epoch = secsSince1900 - seventyYears;
 
-  // print Unix time:
+  // Print Unix time:
   Serial.print("Unix time = ");
   Serial.println(epoch);
 }
@@ -74,7 +74,7 @@ void setup() {
   Serial.begin(9600);
   Serial.println(F("\n[EtherCard NTP Client]"));
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, myMac, SS) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
@@ -98,6 +98,6 @@ void setup() {
 }
 
 void loop() {
-  // this must be called for ethercard functions to work.
+  // This must be called for EtherCard functions to work.
   ether.packetLoop(ether.packetReceive());
 }

--- a/examples/persistence/persistence.ino
+++ b/examples/persistence/persistence.ino
@@ -4,23 +4,23 @@
 
 #include <EtherCard.h>
 
-// ethernet interface mac address, must be unique on the LAN
+// Ethernet interface MAC address, must be unique on the LAN
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
-// the buffersize must be relatively large for DHCP to work; when
-// using static setup a buffer size of 100 is sufficient;
+// The buffersize must be relatively large for DHCP to work; when
+// using static setup, a buffer size of 100 is sufficient
 #define BUFFERSIZE 350
 byte Ethernet::buffer[BUFFERSIZE];
 
 const char website[] PROGMEM = "textfiles.com";
 
 uint32_t nextSeq;
-// called when the client request is complete
+// Called when the client request is complete
 static void my_callback (byte status, word off, word len) {
 
     if (strncmp_P((char*) Ethernet::buffer+off,PSTR("HTTP"),4) == 0) {
         Serial.println(">>>");
-        // first reply packet
+        // First reply packet
         nextSeq = ether.getSequenceNumber();
     }
 
@@ -45,7 +45,7 @@ void setup () {
     Serial.begin(57600);
     Serial.println(F("\n[Persistence+readPacketSlice]"));
 
-    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+    // Change 'SS' to your Slave Select pin if you aren't using the default pin
     if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
         Serial.println(F("Failed to access Ethernet controller"));
     if (!ether.dhcpSetup())

--- a/examples/pings/pings.ino
+++ b/examples/pings/pings.ino
@@ -5,13 +5,13 @@
 
 #include <EtherCard.h>
 
-// ethernet interface mac address, must be unique on the LAN
+// Ethernet interface MAC address, must be unique on the LAN
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[700];
 static uint32_t timer;
 
-// called when a ping comes in (replies to it are automatic)
+// Called when a ping comes in (replies to it are automatic)
 static void gotPinged (byte* ptr) {
   ether.printIp(">>> ping from: ", ptr);
 }
@@ -20,7 +20,7 @@ void setup () {
   Serial.begin(57600);
   Serial.println("\n[pings]");
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
@@ -30,7 +30,7 @@ void setup () {
   ether.printIp("GW:  ", ether.gwip);
 
 #if 1
-  // use DNS to locate the IP address we want to ping
+  // Use DNS to locate the IP address we want to ping
   if (!ether.dnsLookup(PSTR("www.google.com")))
     Serial.println("DNS failed");
 #else
@@ -38,7 +38,7 @@ void setup () {
 #endif
   ether.printIp("SRV: ", ether.hisip);
 
-  // call this to report others pinging us
+  // Call this to report others pinging us
   ether.registerPingCallback(gotPinged);
 
   timer = -9999999; // start timing out right away
@@ -49,14 +49,14 @@ void loop () {
   word len = ether.packetReceive(); // go receive new packets
   word pos = ether.packetLoop(len); // respond to incoming pings
 
-  // report whenever a reply to our outgoing ping comes back
+  // Report whenever a reply to our outgoing ping comes back
   if (len > 0 && ether.packetLoopIcmpCheckReply(ether.hisip)) {
     Serial.print("  ");
     Serial.print((micros() - timer) * 0.001, 3);
     Serial.println(" ms");
   }
 
-  // ping a remote server once every few seconds
+  // Ping a remote server once every few seconds
   if (micros() - timer >= 5000000) {
     ether.printIp("Pinging: ", ether.hisip);
     timer = micros();

--- a/examples/rbbb_server/rbbb_server.ino
+++ b/examples/rbbb_server/rbbb_server.ino
@@ -5,7 +5,7 @@
 
 #include <EtherCard.h>
 
-// ethernet interface mac address, must be unique on the LAN
+// Ethernet interface MAC address, must be unique on the LAN
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 static byte myip[] = { 192,168,1,203 };
 
@@ -33,7 +33,7 @@ static word homePage() {
 void setup () {
   Serial.begin(57600);
   Serial.println(F("\n[RBBB Server]"));
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   ether.staticSetup(myip);
@@ -43,6 +43,6 @@ void loop () {
   word len = ether.packetReceive();
   word pos = ether.packetLoop(len);
 
-  if (pos)  // check if valid tcp data is received
+  if (pos)  // check if valid TCP data is received
     ether.httpServerReply(homePage()); // send web page data
 }

--- a/examples/stashTest/stashTest.ino
+++ b/examples/stashTest/stashTest.ino
@@ -6,7 +6,7 @@
 #include <EtherCard.h>
 #include <avr/eeprom.h>
 
-// ethernet interface mac address, must be unique on the LAN
+// Ethernet interface MAC address, must be unique on the LAN
 byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[700];
@@ -49,7 +49,7 @@ void setup () {
   Serial.begin(57600);
   Serial.println("\n[stashTest]");
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   ether.begin(sizeof Ethernet::buffer, mymac, SS);
 
 #if 1

--- a/examples/testDHCP/testDHCP.ino
+++ b/examples/testDHCP/testDHCP.ino
@@ -23,7 +23,7 @@ void setup () {
   }
   Serial.println();
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
 

--- a/examples/thingspeak/thingspeak.ino
+++ b/examples/thingspeak/thingspeak.ino
@@ -14,11 +14,11 @@
 
 #include <EtherCard.h>
 
-// change these settings to match your own setup
+// Change these settings to match your own setup
 //#define FEED "000"
 #define APIKEY "beef1337beef1337" // put your key here
 
-// ethernet interface mac address, must be unique on the LAN
+// Ethernet interface MAC address, must be unique on the LAN
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 const char website[] PROGMEM = "api.thingspeak.com";
 byte Ethernet::buffer[700];
@@ -31,8 +31,8 @@ int res = 100; // was 0
 
 
 void initialize_ethernet(void){
-  for(;;){ // keep trying until you succeed
-    //Reinitialize ethernet module
+  for(;;) { // keep trying until you succeed
+    // Reinitialize ethernet module
     //pinMode(5, OUTPUT);  // do notknow what this is for, i ve got something elso on pin5
     //Serial.println("Reseting Ethernet...");
     //digitalWrite(5, LOW);
@@ -40,7 +40,7 @@ void initialize_ethernet(void){
     //digitalWrite(5, HIGH);
     //delay(500);
 
-    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+    // Change 'SS' to your Slave Select pin if you aren't using the default pin
     if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0){
       Serial.println( "Failed to access Ethernet controller");
       continue;
@@ -70,12 +70,12 @@ void setup () {
   Serial.begin(9600);
   Serial.println("\n[ThingSpeak example]");
 
-  //Initialize Ethernet
+  // Initialize Ethernet
   initialize_ethernet();
 }
 
 void loop () {
-  //if correct answer is not received then re-initialize ethernet module
+  // If correct answer is not received, then re-initialize ethernet module
   if (res > 220){
     initialize_ethernet();
   }
@@ -99,7 +99,7 @@ void loop () {
       msje = "high";
     }
 
-    // generate two fake values as payload - by using a separate stash,
+    // Generate two fake values as payload - by using a separate stash,
     // we can determine the size of the generated message ahead of time
     // field1=(Field 1 Data)&field2=(Field 2 Data)&field3=(Field 3 Data)&field4=(Field 4 Data)&field5=(Field 5 Data)&field6=(Field 6 Data)&field7=(Field 7 Data)&field8=(Field 8 Data)&lat=(Latitude in Decimal Degrees)&long=(Longitude in Decimal Degrees)&elevation=(Elevation in meters)&status=(140 Character Message)
     byte sd = stash.create();
@@ -111,11 +111,11 @@ void loop () {
     //stash.print(msje);
     stash.save();
 
-    //Display data to be sent
+    // Display data to be sent
     Serial.println(demo);
 
 
-    // generate the header with payload - note that the stash size is used,
+    // Generate the header with payload - note that the stash size is used,
     // and that a "stash descriptor" is passed in as argument using "$H"
     Stash::prepare(PSTR("POST /update HTTP/1.0" "\r\n"
       "Host: $F" "\r\n"
@@ -130,19 +130,19 @@ void loop () {
     // send the packet - this also releases all stash buffers once done
     session = ether.tcpSend();
 
- // added from: http://jeelabs.net/boards/7/topics/2241
- int freeCount = stash.freeCount();
+    // Added from: http://jeelabs.net/boards/7/topics/2241
+    int freeCount = stash.freeCount();
     if (freeCount <= 3) {   Stash::initMap(56); }
   }
 
-   const char* reply = ether.tcpReply(session);
+  const char* reply = ether.tcpReply(session);
 
-   if (reply != 0) {
-     res = 0;
-     Serial.println(F(" >>>REPLY recieved...."));
-     Serial.println(reply);
-   }
-   delay(300);
+  if (reply != 0) {
+    res = 0;
+    Serial.println(F(" >>>REPLY recieved...."));
+    Serial.println(reply);
+  }
+  delay(300);
 }
 
 

--- a/examples/twitter/twitter.ino
+++ b/examples/twitter/twitter.ino
@@ -2,7 +2,7 @@
 // arduino-tweet.appspot.com as a OAuth gateway.
 // Step by step instructions:
 //
-//  1. Get a oauth token:
+//  1. Get a OAuth token:
 //     http://arduino-tweet.appspot.com/oauth/twitter/login
 //  2. Put the token value in the TOKEN define below
 //  3. Run the sketch!
@@ -16,10 +16,10 @@
 
 #include <EtherCard.h>
 
-// OAUTH key from http://arduino-tweet.appspot.com/
+// OAuth key from http://arduino-tweet.appspot.com/
 #define TOKEN   "Insert-your-token-here"
 
-// ethernet interface mac address, must be unique on the LAN
+// Ethernet interface MAC address, must be unique on the LAN
 byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 const char website[] PROGMEM = "arduino-tweet.appspot.com";
@@ -50,8 +50,8 @@ static void sendToTwitter () {
     "$H"),
   website, website, stash_size, sd);
 
-  // send the packet - this also releases all stash buffers once done
-  // Save the session ID so we can watch for it in the main loop.
+  // Send the packet - this also releases all stash buffers once done.
+  // Save the session ID, so we can watch for it in the main loop.
   session = ether.tcpSend();
 }
 
@@ -59,7 +59,7 @@ void setup () {
   Serial.begin(57600);
   Serial.println("\n[Twitter Client]");
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())

--- a/examples/udpClientSendOnly/udpClientSendOnly.ino
+++ b/examples/udpClientSendOnly/udpClientSendOnly.ino
@@ -12,7 +12,7 @@ const int srcPort PROGMEM = 4321;
 void setup () {
   Serial.begin(9600);
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println( "Failed to access Ethernet controller");
   if (!ether.dhcpSetup())

--- a/examples/udpListener/udpListener.ino
+++ b/examples/udpListener/udpListener.ino
@@ -89,18 +89,17 @@ import hypermedia.net.*;
  }
 
  void keyPressed() {
- String ip       = "192.168.0.200";  // the remote IP address
- int port        = 1337;    // the destination port
+   String ip       = "192.168.0.200";  // the remote IP address
+   int port        = 1337;             // the destination port
 
- udp.send("Greetings via UDP!", ip, port );   // the message to send
-
+   udp.send("Greetings via UDP!", ip, port );   // the message to send
  }
 
  void receive( byte[] data ) {       // <-- default handler
  //void receive( byte[] data, String ip, int port ) {  // <-- extended handler
 
- for(int i=0; i < data.length; i++)
- print(char(data[i]));
- println();
+   for (int i=0; i < data.length; i++)
+   print(char(data[i]));
+   println();
  }
 */

--- a/examples/webClient/webClient.ino
+++ b/examples/webClient/webClient.ino
@@ -5,7 +5,7 @@
 
 #include <EtherCard.h>
 
-// ethernet interface mac address, must be unique on the LAN
+// Ethernet interface MAC address, must be unique on the LAN
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[700];
@@ -13,7 +13,16 @@ static uint32_t timer;
 
 const char website[] PROGMEM = "www.google.com";
 
-// called when the client request is complete
+/*
+1: Use DNS to resolve the website's IP address
+2: If website is a string containing an IP address instead of a domain name,
+   then use it directly. Note: the string can not be in PROGMEM.
+Other:
+   Provide a numeric IP address instead of a string
+*/
+#define USE_VARIANT 1
+
+// Called when the client request is complete
 static void my_callback (byte status, word off, word len) {
   Serial.println(">>>");
   Ethernet::buffer[off+300] = 0;
@@ -25,7 +34,7 @@ void setup () {
   Serial.begin(57600);
   Serial.println(F("\n[webClient]"));
 
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  // Change 'SS' to your Slave Select pin if you aren't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
@@ -35,12 +44,12 @@ void setup () {
   ether.printIp("GW:  ", ether.gwip);
   ether.printIp("DNS: ", ether.dnsip);
 
-#if 1
-  // use DNS to resolve the website's IP address
+#if (1 == USE_VARIANT)
+  // Use DNS to resolve the website's IP address
   if (!ether.dnsLookup(website))
     Serial.println("DNS failed");
-#elif 2
-  // if website is a string containing an IP address instead of a domain name,
+#elif (2 == USE_VARIANT)
+  // If website is a string containing an IP address instead of a domain name,
   // then use it directly. Note: the string can not be in PROGMEM.
   char websiteIP[] = "192.168.1.1";
   ether.parseIp(ether.hisip, websiteIP);

--- a/examples/xively/xively.ino
+++ b/examples/xively/xively.ino
@@ -8,11 +8,11 @@
 
 #include <EtherCard.h>
 
-// change these settings to match your own setup
+// Change these settings to match your own setup
 #define FEED "000"
 #define APIKEY "xxx"
 
-// ethernet interface mac address, must be unique on the LAN
+// Ethernet interface MAC address, must be unique on the LAN
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 const char website[] PROGMEM = "api.xively.com";
@@ -27,7 +27,7 @@ int res = 0;
 
 void initialize_ethernet(void){
   for(;;){ // keep trying until you succeed
-    //Reinitialize ethernet module
+    // Reinitialize ethernet module
     pinMode(5, OUTPUT);
     Serial.println("Reseting Ethernet...");
     digitalWrite(5, LOW);
@@ -35,7 +35,7 @@ void initialize_ethernet(void){
     digitalWrite(5, HIGH);
     delay(500);
 
-    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+    // Change 'SS' to your Slave Select pin if you aren't using the default pin
     if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0){
       Serial.println( "Failed to access Ethernet controller");
       continue;
@@ -55,7 +55,7 @@ void initialize_ethernet(void){
 
     ether.printIp("SRV: ", ether.hisip);
 
-    //reset init value
+    // Reset init value
     res = 0;
     break;
   }
@@ -67,14 +67,14 @@ void setup () {
   Serial.begin(57600);
   Serial.println("\n[Xively example]");
 
-  //Initialize Ethernet
+  // Initialize Ethernet
   initialize_ethernet();
 }
 
 
 void loop () {
 
-  //if correct answer is not received then re-initialize ethernet module
+  // If correct answer is not received, then re-initialize ethernet module
   if (res > 220){
     initialize_ethernet();
   }
@@ -83,7 +83,7 @@ void loop () {
 
   ether.packetLoop(ether.packetReceive());
 
-  //200 res = 10 seconds (50ms each res)
+  // 200 res = 10 seconds (50ms each res)
   if (res == 200) {
 
 
@@ -100,7 +100,7 @@ void loop () {
     }
 
 
-    // generate two fake values as payload - by using a separate stash,
+    // Generate two fake values as payload - by using a separate stash,
     // we can determine the size of the generated message ahead of time
     byte sd = stash.create();
     stash.print("demo,");
@@ -111,12 +111,12 @@ void loop () {
     stash.println(msje);
     stash.save();
 
-    //Display data to be sent
+    // Display data to be sent
     Serial.println(demo);
     Serial.println(one);
 
 
-    // generate the header with payload - note that the stash size is used,
+    // Generate the header with payload - note that the stash size is used,
     // and that a "stash descriptor" is passed in as argument using "$H"
     Stash::prepare(PSTR("PUT http://$F/v2/feeds/$F.csv HTTP/1.0" "\r\n"
       "Host: $F" "\r\n"
@@ -126,7 +126,7 @@ void loop () {
       "$H"),
     website, PSTR(FEED), website, PSTR(APIKEY), stash.size(), sd);
 
-    // send the packet - this also releases all stash buffers once done
+    // Send the packet - this also releases all stash buffers once done
     session = ether.tcpSend();
   }
 


### PR DESCRIPTION
In analogy to

https://github.com/njh/EtherCard/pull/371

I went through all examples and enhanced the readability of comments by using the style policy that every line comment should begin with a capital letter. Additionally capitalized words such as TCP, IP etc.

Additionally fixed a bug in examples/webClient/webClient.ino

What is this bug?

In this file, there exist lines

```
#if 1
...
#if 2
...
```

But these must not be used the same time. So I added a macro `USE_VARIANT`. By modifying its value, you can choose which version to use.