### PR TITLE
read MAC address from PROGMEM

### DIFF
--- a/examples/JeeUdp/JeeUdp.ino
+++ b/examples/JeeUdp/JeeUdp.ino
@@ -25,7 +25,7 @@ struct Config {
 } config;
 
 // ethernet interface mac address - must be unique on your network
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 // buffer for an outgoing data packet
 static byte outBuf[RF12_MAXDATA], outDest;
@@ -261,7 +261,7 @@ void setup (){
   loadConfig();
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println( "Failed to access Ethernet controller");
   if (!ether.dhcpSetup())
     Serial.println("DHCP failed");

--- a/examples/SSDP/SSDP.ino
+++ b/examples/SSDP/SSDP.ino
@@ -10,7 +10,7 @@ const char SSDP_NOTIFY[] PROGMEM = "NOTIFY * HTTP/1.1\r\nHOST: 239.255.255.250:1
 static byte myip[] = { 192,168,0,67 };
 static byte gwip[] = { 192,168,0,250 };
 static byte ssdp[] = { 239,255,255,250 };
-static byte mymac[] = { 0x74,0x99,0x69,0x2D,0x30,0x40 }; // if you change it you must update SSDP_RESPONSE and XML_DESCRIP
+const static byte mymac[] PROGMEM = { 0x74,0x99,0x69,0x2D,0x30,0x40 }; // if you change it you must update SSDP_RESPONSE and XML_DESCRIP
 byte Ethernet::buffer[750]; // tcp ip send and receive buffer
 unsigned long timer=9999;
 const char pageA[] PROGMEM =
@@ -99,7 +99,7 @@ void addip(int udppos) { // add current ip to the request and send it
 
 void setup(){
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  ether.begin(sizeof Ethernet::buffer, mymac, SS);
+  ether.begin(sizeof Ethernet::buffer, mymac, SS, false);
   ether.staticSetup(myip, gwip);
   ENC28J60::disableMulticast(); //disable multicast filter means enable multicast reception
   Serial.begin(115200);

--- a/examples/backSoon/backSoon.ino
+++ b/examples/backSoon/backSoon.ino
@@ -15,7 +15,7 @@ static byte gwip[] = { 192,168,1,1 };
 #endif
 
 // ethernet mac address - must be unique on your network
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[500]; // tcp/ip send and receive buffer
 
@@ -43,7 +43,7 @@ void setup(){
   Serial.println("\n[backSoon]");
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println( "Failed to access Ethernet controller");
 #if STATIC
   ether.staticSetup(myip, gwip);

--- a/examples/etherNode/etherNode.ino
+++ b/examples/etherNode/etherNode.ino
@@ -28,7 +28,7 @@ struct Config {
 } config;
 
 // ethernet interface mac address - must be unique on your network
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 // buffer for an outgoing data packet
 static byte outBuf[RF12_MAXDATA], outDest;
@@ -217,7 +217,7 @@ void setup(){
     loadConfig();
 
     // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-    if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+    if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
       Serial.println( "Failed to access Ethernet controller");
     if (!ether.dhcpSetup())
       Serial.println("DHCP failed");

--- a/examples/getDHCPandDNS/getDHCPandDNS.ino
+++ b/examples/getDHCPandDNS/getDHCPandDNS.ino
@@ -8,7 +8,7 @@
 #define REQUEST_RATE 5000 // milliseconds
 
 // ethernet interface mac address
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 // remote website name
 const char website[] PROGMEM = "google.com";
 
@@ -28,7 +28,7 @@ void setup () {
   Serial.println("\n[getDHCPandDNS]");
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println( "Failed to access Ethernet controller");
 
   if (!ether.dhcpSetup())

--- a/examples/getStaticIP/getStaticIP.ino
+++ b/examples/getStaticIP/getStaticIP.ino
@@ -8,7 +8,7 @@
 #define REQUEST_RATE 5000 // milliseconds
 
 // ethernet interface mac address
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 // ethernet interface ip address
 static byte myip[] = { 192,168,1,203 };
 // ethernet interface ip netmask
@@ -36,7 +36,7 @@ void setup () {
   Serial.println("\n[getStaticIP]");
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println( "Failed to access Ethernet controller");
 
   ether.staticSetup(myip, gwip, NULL, mask);

--- a/examples/getViaDNS/getViaDNS.ino
+++ b/examples/getViaDNS/getViaDNS.ino
@@ -8,7 +8,7 @@
 #define REQUEST_RATE 5000 // milliseconds
 
 // ethernet interface mac address
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 // ethernet interface ip address
 static byte myip[] = { 192,168,1,203 };
 // ethernet interface ip netmask
@@ -34,7 +34,7 @@ void setup () {
   Serial.println("\n[getViaDNS]");
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println( "Failed to access Ethernet controller");
 
   ether.staticSetup(myip, gwip, NULL, mask);

--- a/examples/multipacket/multipacket.ino
+++ b/examples/multipacket/multipacket.ino
@@ -3,7 +3,7 @@
 #define TCP_FLAGS_ACK_V 0x10 //as declared in net.h
 static byte myip[] = { 192,168,0,66 };
 static byte gwip[] = { 192,168,0,250 };
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x39 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x39 };
 byte Ethernet::buffer[900]; // tcp ip send and receive buffer
 const char pageA[] PROGMEM =
 "HTTP/1.0 200 OK\r\n"
@@ -48,7 +48,7 @@ const char pageE[] PROGMEM =
 
 void setup(){
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  ether.begin(sizeof Ethernet::buffer, mymac , SS);
+  ether.begin(sizeof Ethernet::buffer, mymac , SS, false);
   ether.staticSetup(myip, gwip);
 }
 

--- a/examples/multipacketSD/multipacketSD.ino
+++ b/examples/multipacketSD/multipacketSD.ino
@@ -16,7 +16,7 @@
 #define TCP_FLAGS_ACK_V 16 //as declared in net.h
 static byte myip[] = { 192,168,0,66 };
 static byte gwip[] = { 192,168,0,250 };
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x39 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x39 };
 byte Ethernet::buffer[700]; // tcp/ip send and receive buffer
 unsigned long cur;
 unsigned long pos;
@@ -103,7 +103,7 @@ void setup()
   if (res==NO_ERROR)    Serial.println("SD started");
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  ether.begin(sizeof Ethernet::buffer, mymac , SS);
+  ether.begin(sizeof Ethernet::buffer, mymac , SS, false);
   ether.staticSetup(myip, gwip);
   Serial.println("ETH started");
 }

--- a/examples/nanether/nanether.ino
+++ b/examples/nanether/nanether.ino
@@ -6,7 +6,7 @@
 
 #define BUF_SIZE 512
 
-byte mac[] = { 0x00, 0x04, 0xA3, 0x21, 0xCA, 0x38 };   // Nanode MAC address.
+const byte mac[] PROGMEM = { 0x00, 0x04, 0xA3, 0x21, 0xCA, 0x38 };   // Nanode MAC address.
 
 uint8_t ip[] = { 192, 168, 1, 8 };          // The fallback board address.
 uint8_t dns[] = { 192, 168, 1, 20 };        // The DNS server address.
@@ -24,7 +24,7 @@ void setup(void)
     Serial.println("Initialising the Ethernet controller");
 
     // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-    if (ether.begin(sizeof Ethernet::buffer, mac, SS) == 0) {
+    if (ether.begin(sizeof Ethernet::buffer, mac, SS, false) == 0) {
         Serial.println( "Ethernet controller NOT initialised");
         while (true)
             /* MT */ ;

--- a/examples/noipClient/noipClient.ino
+++ b/examples/noipClient/noipClient.ino
@@ -27,7 +27,7 @@
 #define MAX_ATTEMPTS         3
 
 // MAC Address of Ethernet Shield
-static byte mymac[] = {0xDD,0xDD,0xDD,0x00,0x00,0x01};
+const static byte mymac[] PROGMEM = {0xDD,0xDD,0xDD,0x00,0x00,0x01};
 
 // Insert your hostname and authentication string
 const char noIP_host[] PROGMEM = "myhost.no-ip.info";
@@ -213,7 +213,7 @@ void setup () {
     Serial.println();
 
     // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-    if (!ether.begin(sizeof Ethernet::buffer, mymac, SS))
+    if (!ether.begin(sizeof Ethernet::buffer, mymac, SS, false))
         Serial.println(F( "Failed to access Ethernet controller"));
     else
         Serial.println(F("Ethernet controller initialized"));

--- a/examples/notifyMyAndroid/notifyMyAndroid.ino
+++ b/examples/notifyMyAndroid/notifyMyAndroid.ino
@@ -12,7 +12,7 @@
 
 const char apihost[] PROGMEM = "www.notifymyandroid.com";
 
-static byte mymac[] = { 0x74, 0x69, 0x69, 0x2D, 0x30, 0x31 };
+const static byte mymac[] PROGMEM = { 0x74, 0x69, 0x69, 0x2D, 0x30, 0x31 };
 
 byte Ethernet::buffer[900];
 Stash stash;
@@ -59,7 +59,7 @@ void setup () {
   Serial.println("\nStarting Notify My Android Example");
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));

--- a/examples/ntpClient/ntpClient.ino
+++ b/examples/ntpClient/ntpClient.ino
@@ -75,7 +75,7 @@ void setup() {
   Serial.println(F("\n[EtherCard NTP Client]"));
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, myMac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, myMac, SS, false) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));

--- a/examples/persistence/persistence.ino
+++ b/examples/persistence/persistence.ino
@@ -5,7 +5,7 @@
 #include <EtherCard.h>
 
 // ethernet interface mac address, must be unique on the LAN
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 // the buffersize must be relatively large for DHCP to work; when
 // using static setup a buffer size of 100 is sufficient;
@@ -46,7 +46,7 @@ void setup () {
     Serial.println(F("\n[Persistence+readPacketSlice]"));
 
     // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-    if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+    if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
         Serial.println(F("Failed to access Ethernet controller"));
     if (!ether.dhcpSetup())
         Serial.println(F("DHCP failed"));

--- a/examples/pings/pings.ino
+++ b/examples/pings/pings.ino
@@ -6,7 +6,7 @@
 #include <EtherCard.h>
 
 // ethernet interface mac address, must be unique on the LAN
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[700];
 static uint32_t timer;
@@ -21,7 +21,7 @@ void setup () {
   Serial.println("\n[pings]");
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));

--- a/examples/rbbb_server/rbbb_server.ino
+++ b/examples/rbbb_server/rbbb_server.ino
@@ -6,7 +6,7 @@
 #include <EtherCard.h>
 
 // ethernet interface mac address, must be unique on the LAN
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 static byte myip[] = { 192,168,1,203 };
 
 byte Ethernet::buffer[500];
@@ -34,7 +34,7 @@ void setup () {
   Serial.begin(57600);
   Serial.println(F("\n[RBBB Server]"));
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   ether.staticSetup(myip);
 }

--- a/examples/stashTest/stashTest.ino
+++ b/examples/stashTest/stashTest.ino
@@ -7,7 +7,7 @@
 #include <avr/eeprom.h>
 
 // ethernet interface mac address, must be unique on the LAN
-byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[700];
 
@@ -50,7 +50,7 @@ void setup () {
   Serial.println("\n[stashTest]");
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  ether.begin(sizeof Ethernet::buffer, mymac, SS);
+  ether.begin(sizeof Ethernet::buffer, mymac, SS, false);
 
 #if 1
   Stash buf;

--- a/examples/testDHCP/testDHCP.ino
+++ b/examples/testDHCP/testDHCP.ino
@@ -7,7 +7,7 @@
 
 #include <EtherCard.h>
 
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[700];
 
@@ -24,7 +24,7 @@ void setup () {
   Serial.println();
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
 
   Serial.println(F("Setting up DHCP"));

--- a/examples/testDHCPOptions/testDHCPOptions.ino
+++ b/examples/testDHCPOptions/testDHCPOptions.ino
@@ -5,7 +5,7 @@
 
 #include <EtherCard.h>
 
-static byte mymac[] = { 0x6e, 0x1b, 0xd0, 0x2e, 0xdd, 0xa5 };
+const static byte mymac[] PROGMEM = { 0x6e, 0x1b, 0xd0, 0x2e, 0xdd, 0xa5 };
 
 byte Ethernet::buffer[700];
 
@@ -28,7 +28,7 @@ void setup () {
   }
   Serial.println();
   
-  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) 
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8, false) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
 
   // Add callback for the NTP option (DHCP Option number 42)

--- a/examples/thingspeak/thingspeak.ino
+++ b/examples/thingspeak/thingspeak.ino
@@ -19,7 +19,7 @@
 #define APIKEY "beef1337beef1337" // put your key here
 
 // ethernet interface mac address, must be unique on the LAN
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 const char website[] PROGMEM = "api.thingspeak.com";
 byte Ethernet::buffer[700];
 uint32_t timer;
@@ -41,7 +41,7 @@ void initialize_ethernet(void){
     //delay(500);
 
     // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-    if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0){
+    if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0){
       Serial.println( "Failed to access Ethernet controller");
       continue;
     }

--- a/examples/twitter/twitter.ino
+++ b/examples/twitter/twitter.ino
@@ -20,7 +20,7 @@
 #define TOKEN   "Insert-your-token-here"
 
 // ethernet interface mac address, must be unique on the LAN
-byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 const char website[] PROGMEM = "arduino-tweet.appspot.com";
 
@@ -60,7 +60,7 @@ void setup () {
   Serial.println("\n[Twitter Client]");
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));

--- a/examples/udpClientSendOnly/udpClientSendOnly.ino
+++ b/examples/udpClientSendOnly/udpClientSendOnly.ino
@@ -1,6 +1,6 @@
 #include <EtherCard.h>
 
-static byte mymac[] = { 0x1A,0x2B,0x3C,0x4D,0x5E,0x6F };
+const static byte mymac[] PROGMEM = { 0x1A,0x2B,0x3C,0x4D,0x5E,0x6F };
 byte Ethernet::buffer[700];
 static uint32_t timer;
 
@@ -13,7 +13,7 @@ void setup () {
   Serial.begin(9600);
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println( "Failed to access Ethernet controller");
   if (!ether.dhcpSetup())
     Serial.println("DHCP failed");

--- a/examples/udpListener/udpListener.ino
+++ b/examples/udpListener/udpListener.ino
@@ -19,7 +19,7 @@ static byte gwip[] = { 192,168,0,1 };
 #endif
 
 // Ethernet MAC address - must be unique on your network
-static byte mymac[] = { 0x70,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x70,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[500]; // TCP/IP send and receive buffer
 
@@ -44,7 +44,7 @@ void setup(){
   Serial.println(F("\n[backSoon]"));
 
   // Change 'SS' to your Slave Select pin if you aren't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
 #if STATIC
   ether.staticSetup(myip, gwip);

--- a/examples/webClient/webClient.ino
+++ b/examples/webClient/webClient.ino
@@ -6,7 +6,7 @@
 #include <EtherCard.h>
 
 // ethernet interface mac address, must be unique on the LAN
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 byte Ethernet::buffer[700];
 static uint32_t timer;
@@ -26,7 +26,7 @@ void setup () {
   Serial.println(F("\n[webClient]"));
 
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0)
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));

--- a/examples/xively/xively.ino
+++ b/examples/xively/xively.ino
@@ -13,7 +13,7 @@
 #define APIKEY "xxx"
 
 // ethernet interface mac address, must be unique on the LAN
-static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
+const static byte mymac[] PROGMEM = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 
 const char website[] PROGMEM = "api.xively.com";
 
@@ -36,7 +36,7 @@ void initialize_ethernet(void){
     delay(500);
 
     // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-    if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0){
+    if (ether.begin(sizeof Ethernet::buffer, mymac, SS, false) == 0){
       Serial.println( "Failed to access Ethernet controller");
       continue;
     }

--- a/src/EtherCard.cpp
+++ b/src/EtherCard.cpp
@@ -30,12 +30,16 @@ uint16_t EtherCard::delaycnt = 0; //request gateway ARP lookup
 
 uint8_t EtherCard::begin (const uint16_t size,
                           const uint8_t* macaddr,
-                          uint8_t csPin) {
+                          const uint8_t csPin, const bool fromRam) {
     using_dhcp = false;
 #if ETHERCARD_STASH
     Stash::initMap();
 #endif
-    copyMac(mymac, macaddr);
+    if(fromRam) {
+        copyMac(mymac, macaddr);
+    } else {
+        copyMac_P(mymac, macaddr);
+    }
     return initialize(size, mymac, csPin);
 }
 

--- a/src/EtherCard.h
+++ b/src/EtherCard.h
@@ -125,10 +125,11 @@ public:
     *     @param  size Size of data buffer
     *     @param  macaddr Hardware address to assign to the network interface (6 bytes)
     *     @param  csPin Arduino pin number connected to chip select. Default = 8
+    *     @param  fromRam Set true to indicate whether macaddr is in RAM or in program space. Default = true
     *     @return <i>uint8_t</i> Firmware version or zero on failure.
     */
     static uint8_t begin (const uint16_t size, const uint8_t* macaddr,
-                          uint8_t csPin = SS);
+                          const uint8_t csPin = SS, const bool fromRam =true);
 
     /**   @brief  Configure network interface with static IP
     *     @param  my_ip IP address (4 bytes). 0 for no change.
@@ -393,6 +394,13 @@ public:
     *     @note   There is no check of source or destination size. Ensure both are 6 bytes
     */
     static void copyMac (uint8_t *dst, const uint8_t *src);
+
+    /**   @brief  Copies a hardware address from program space
+    *     @param  dst Pointer to the 6 byte destination
+    *     @param  src Pointer to the 6 byte destination
+    *     @note   There is no check of source or destination size. Ensure both are 6 bytes
+    */
+    static void copyMac_P (uint8_t *dst, const uint8_t *src);
 
     /**   @brief  Output to serial port in dotted decimal IP format
     *     @param  buf Pointer to 4 byte IP address

--- a/src/enc28j60.cpp
+++ b/src/enc28j60.cpp
@@ -363,7 +363,7 @@ static void writePhy (byte address, uint16_t data) {
         ;
 }
 
-byte ENC28J60::initialize (uint16_t size, const byte* macaddr, byte csPin) {
+byte ENC28J60::initialize (uint16_t size, const byte* macaddr, const byte csPin) {
     bufferSize = size;
     if (bitRead(SPCR, SPE) == 0)
         initSPI();

--- a/src/enc28j60.h
+++ b/src/enc28j60.h
@@ -57,7 +57,7 @@ public:
     *     @return <i>uint8_t</i> ENC28J60 firmware version or zero on failure.
     */
     static uint8_t initialize (const uint16_t size, const uint8_t* macaddr,
-                               uint8_t csPin = 8);
+                               const uint8_t csPin = 8);
 
     /**   @brief  Check if network link is connected
     *     @return <i>bool</i> True if link is up

--- a/src/webutil.cpp
+++ b/src/webutil.cpp
@@ -14,6 +14,10 @@ void EtherCard::copyMac (uint8_t *dst, const uint8_t *src) {
     memcpy(dst, src, ETH_LEN);
 }
 
+void EtherCard::copyMac_P (uint8_t *dst, const uint8_t *src) {
+    memcpy_P(dst, src, ETH_LEN);
+}
+
 void EtherCard::printIp (const char* msg, const uint8_t *buf) {
     Serial.print(msg);
     EtherCard::printIp(buf);


### PR DESCRIPTION
This fixes #397 by adding support for reading the MAC address from PROGMEM.

I wanted to do it using an overloaded begin() method, but it turns out that it's not possible to do that using the PROGMEM macro (see https://github.com/njh/EtherCard/pull/399#issuecomment-731627907) :disappointed: .
Therefore, I implemented it using an optional `fromRam` argument, as is done in other places.
Despite having updated all examples to read from `PROGMEM`, the `fromRam` argument is kept as `true` by default so as not to break other people's code when they update the library.
This does have the downside that it's not possible to place the MAC in PROGMEM without passing a `csPin` to `begin()`.

@nagimov It's been a few months but I'd be grateful if you could still test this :)

closes #399
closes #398
fixes #397 (ntpClient example)